### PR TITLE
Add --output-json option for JSON event output

### DIFF
--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/Run.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/Run.scala
@@ -55,7 +55,7 @@ object Run {
       enrichmentRegistry <- buildEnrichmentRegistry(config.enrichmentsConfig)
       badProcessor = Processor(BuildInfo.name, BuildInfo.version)
       lookup = JavaNetRegistryLookup.ioLookupInstance[IO]
-      sink = new MemorySink(config.iglu.client, lookup, enrichmentRegistry, config.outputEnrichedTsv, badProcessor, config.enrichConfig)
+      sink = new MemorySink(config.iglu.client, lookup, enrichmentRegistry, config.outputFormat, badProcessor, config.enrichConfig)
       collectorService = new Service[IO](
         config.collector,
         Sinks(sink, sink),

--- a/src/test/scala/com.snowplowanalytics.snowplow.micro/ConfigHelperSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.micro/ConfigHelperSpec.scala
@@ -13,7 +13,7 @@ package com.snowplowanalytics.snowplow.micro
 import cats.effect.IO
 import cats.effect.testing.specs2.CatsEffect
 import com.monovore.decline.Command
-import com.snowplowanalytics.snowplow.micro.Configuration.MicroConfig
+import com.snowplowanalytics.snowplow.micro.Configuration.{MicroConfig, OutputFormat}
 import org.specs2.mutable.Specification
 
 class ConfigHelperSpec extends Specification with CatsEffect {
@@ -30,7 +30,7 @@ class ConfigHelperSpec extends Specification with CatsEffect {
               config.enrichmentsConfig.isEmpty must beTrue
               config.iglu.resolver.repos.map(_.config.name) must containTheSameElementsAs(List("Iglu Central", "Iglu Central - Mirror 01"))
               
-              config.outputEnrichedTsv must beFalse
+              config.outputFormat must beEqualTo(OutputFormat.None)
           }
         }
     }

--- a/src/test/scala/com.snowplowanalytics.snowplow.micro/MemorySinkSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.micro/MemorySinkSpec.scala
@@ -22,6 +22,7 @@ import com.snowplowanalytics.snowplow.badrows.Processor
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.EnrichmentRegistry
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.JavascriptScriptEnrichment
 import com.snowplowanalytics.snowplow.enrich.common.utils.OptionIor
+import com.snowplowanalytics.snowplow.micro.Configuration.OutputFormat
 import org.specs2.mutable.SpecificationLike
 
 import scala.io.Source
@@ -163,7 +164,7 @@ class MemorySinkSpec extends CatsResource[IO, MemorySink] with SpecificationLike
       enrichmentRegistry = new EnrichmentRegistry[IO](javascriptScript = List(jsEnrichment))
       processor = Processor(BuildInfo.name, BuildInfo.version)
       lookup = JavaNetRegistryLookup.ioLookupInstance[IO]
-    } yield new MemorySink(igluClient, lookup, enrichmentRegistry, false, processor, enrichConfig)
+    } yield new MemorySink(igluClient, lookup, enrichmentRegistry, OutputFormat.None, processor, enrichConfig)
   }
 
   private def buildJSEnrichment(): IO[JavascriptScriptEnrichment] = {


### PR DESCRIPTION
This is useful for generating test data for Event Forwarding without having to chain Micro into Snowbridge.

- Replace outputEnrichedTsv boolean with OutputFormat sealed trait (None, Tsv, Json)
- Add --output-json CLI flag with mutually exclusive validation
- Update MemorySink to handle JSON output using toJson(lossy=true)
- Maintain backward compatibility with existing --output-tsv option

🤖 Generated with [Claude Code](https://claude.ai/code)