### PR TITLE
Add a new endpoint that returns both good and incomplete events

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ lazy val dependencies = Seq(
   libraryDependencies ++= Seq(
     Dependencies.snowplowStreamCollector,
     Dependencies.snowplowCommonEnrich,
+    Dependencies.snowplowAnalyticsSdk,
     Dependencies.decline,
     Dependencies.http4sCirce,
     Dependencies.circeJawn,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,6 +18,7 @@ object Dependencies {
     // Snowplow
     val snowplowStreamCollector = "3.7.0"
     val snowplowCommonEnrich    = "6.1.2"
+    val snowplowAnalyticsSdk    = "3.2.0"
     val http4sCirce             = "0.23.23"
 
     val decline          = "2.4.1"
@@ -35,7 +36,8 @@ object Dependencies {
   }
 
   val snowplowStreamCollector = "com.snowplowanalytics" %% "snowplow-stream-collector-http4s-core" % V.snowplowStreamCollector 
-  val snowplowCommonEnrich    = "com.snowplowanalytics" %% "snowplow-common-enrich"                % V.snowplowCommonEnrich 
+  val snowplowCommonEnrich    = "com.snowplowanalytics" %% "snowplow-common-enrich"                % V.snowplowCommonEnrich
+  val snowplowAnalyticsSdk    = "com.snowplowanalytics" %% "snowplow-scala-analytics-sdk"          % V.snowplowAnalyticsSdk
   
   val http4sCirce = "org.http4s"    %% "http4s-circe"   % V.http4sCirce 
   val decline     = "com.monovore"  %% "decline-effect" % V.decline

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/Routing.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/Routing.scala
@@ -35,6 +35,8 @@ final class Routing(igluResolver: Resolver[IO])
   val value: HttpRoutes[IO] = HttpRoutes.of[IO] {
     case request@method -> "micro" /: path =>
       (method, path.segments.head.encoded) match {
+        case (GET, "events") =>
+          Ok(ValidationCache.getGoodAndIncomplete.map(_.event.toJson(lossy = true)))
         case (POST | GET, "all") =>
           Ok(ValidationCache.getSummary())
         case (POST | GET, "reset") =>

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/model.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/model.scala
@@ -20,7 +20,8 @@ private [micro] final case class GoodEvent(
   eventType: Option[String],
   schema: Option[String],
   contexts: List[String],
-  event: Event
+  event: Event,
+  incomplete: Boolean = false
 )
 
 /** A list of this case class is returned when /micro/bad is queried. */

--- a/src/test/scala/com.snowplowanalytics.snowplow.micro/MemorySinkSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.micro/MemorySinkSpec.scala
@@ -72,7 +72,7 @@ class MemorySinkSpec extends CatsResource[IO, MemorySink] with SpecificationLike
       val expected = "Error while validating the event"
       sink.validateEvent(withoutEvent).value.map {
         _ must beLike {
-          case OptionIor.Left((errors, _)) if errors.exists(_.contains(expected)) => ok
+          case OptionIor.Both((errors, _), _) if errors.exists(_.contains(expected)) => ok
         }
       }
     }
@@ -82,7 +82,7 @@ class MemorySinkSpec extends CatsResource[IO, MemorySink] with SpecificationLike
       val expected = "Error while validating the event"
       sink.validateEvent(raw).value.map {
         _ must beLike {
-          case OptionIor.Left((errors, _)) if errors.exists(_.contains(expected)) => ok
+          case OptionIor.Both((errors, _), _) if errors.exists(_.contains(expected)) => ok
         }
       }
     }
@@ -92,7 +92,7 @@ class MemorySinkSpec extends CatsResource[IO, MemorySink] with SpecificationLike
       val expected = "Error while validating the event"
       sink.validateEvent(raw).value.map {
         _ must beLike {
-          case OptionIor.Left((errors, _)) if errors.exists(_.contains(expected)) => ok
+          case OptionIor.Both((errors, _), _) if errors.exists(_.contains(expected)) => ok
         }
       }
     }
@@ -102,7 +102,7 @@ class MemorySinkSpec extends CatsResource[IO, MemorySink] with SpecificationLike
       val expected = "Error while validating the event"
       sink.validateEvent(raw).value.map {
         _ must beLike {
-          case OptionIor.Left((errors, _)) if errors.exists(_.contains(expected)) => ok
+          case OptionIor.Both((errors, _), _) if errors.exists(_.contains(expected)) => ok
         }
       }
     }
@@ -112,7 +112,7 @@ class MemorySinkSpec extends CatsResource[IO, MemorySink] with SpecificationLike
       val expected = "Error while validating the event"
       sink.validateEvent(raw).value.map {
         _ must beLike {
-          case OptionIor.Left((errors, _)) if errors.exists(_.contains(expected)) => ok
+          case OptionIor.Both((errors, _), _) if errors.exists(_.contains(expected)) => ok
         }
       }
     }
@@ -122,7 +122,7 @@ class MemorySinkSpec extends CatsResource[IO, MemorySink] with SpecificationLike
       val expected = "page_ping"
       sink.validateEvent(raw).value.map {
         _ must beLike {
-          case OptionIor.Right(GoodEvent(_, typE, _, _, _)) if typE === Some(expected) => ok
+          case OptionIor.Right(GoodEvent(_, typE, _, _, _, _)) if typE === Some(expected) => ok
         }
       }
     }
@@ -132,7 +132,7 @@ class MemorySinkSpec extends CatsResource[IO, MemorySink] with SpecificationLike
       val expected = schemaLinkClick
       sink.validateEvent(raw).value.map {
         _ must beLike {
-          case OptionIor.Right(GoodEvent(_, _, schema, _, _)) if schema === Some(expected) => ok
+          case OptionIor.Right(GoodEvent(_, _, schema, _, _, _)) if schema === Some(expected) => ok
         }
       }
     }
@@ -142,7 +142,7 @@ class MemorySinkSpec extends CatsResource[IO, MemorySink] with SpecificationLike
       val expected = List(schemaLinkClick, schemaMobileContext)
       sink.validateEvent(raw).value.map {
         _ must beLike {
-          case OptionIor.Right(GoodEvent(_, _, _, contexts, _)) if contexts === expected => ok
+          case OptionIor.Right(GoodEvent(_, _, _, contexts, _, _)) if contexts === expected => ok
         }
       }
     }


### PR DESCRIPTION
* Set emitIncomplete to true
* Store incomplete events in the good list with an extra flag
* Filter out incomplete events for all existing endpoints to keep compatibility
* Add a new endpoint that returns both good and incomplete events