### PR TITLE
Allow resetting columns to the defaults

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -46,7 +46,7 @@ function App() {
     }, 100)
   }
 
-  const { availableColumns, selectedColumns, toggleColumn, reorderColumns } =
+  const { availableColumns, selectedColumns, toggleColumn, reorderColumns, resetToDefaults } =
     useColumnManager({ events, setColumnFilters, onColumnAdded: scrollToLastColumn })
 
   // Filter events based on selected minute
@@ -321,6 +321,7 @@ function App() {
               selectedColumns={selectedColumns}
               onToggleColumn={toggleColumn}
               onClose={() => setShowColumnSelector(false)}
+              onResetToDefaults={resetToDefaults}
             />
           </div>
         )}

--- a/ui/src/hooks/useColumnManager.ts
+++ b/ui/src/hooks/useColumnManager.ts
@@ -8,7 +8,7 @@ import { type ColumnMetadata, createColumnMetadata } from '@/utils/column-metada
 const STORAGE_KEY = 'snowplow-micro-selected-columns'
 
 // Default column configuration
-const DEFAULT_COLUMNS = ['collector_tstamp', 'app_id', 'event_name'] as const
+const DEFAULT_COLUMNS = ['collector_tstamp', 'app_id', 'event_name']
 
 /**
  * Save selected columns to localStorage
@@ -54,6 +54,7 @@ type UseColumnManagerReturn = {
   selectedColumns: ColumnMetadata[]
   toggleColumn: (fieldName: string) => void
   reorderColumns: (fromIndex: number, toIndex: number) => void
+  resetToDefaults: () => void
 }
 
 export function useColumnManager({
@@ -115,10 +116,17 @@ export function useColumnManager({
     setSelectedColumnNames(reordered)
   }
 
+  const resetToDefaults = () => {
+    const removedColumns = selectedColumnNames.filter(col => !DEFAULT_COLUMNS.includes(col))
+    setColumnFilters((filters) => filters.filter((f) => !removedColumns.includes(f.id)))
+    setSelectedColumnNames([...DEFAULT_COLUMNS])
+  }
+
   return {
     availableColumns,
     selectedColumns,
     toggleColumn,
     reorderColumns,
+    resetToDefaults,
   }
 }


### PR DESCRIPTION
- Add resetToDefaults function to useColumnManager hook that resets to default columns and removes filters for removed columns
- Add reset button with RotateCcw icon below selected columns when "selected" tab is active
- Update ColumnSelector component to accept onResetToDefaults prop
- Wire up reset functionality in App component

🤖 Generated with [Claude Code](https://claude.ai/code)