### PR TITLE
Add periodic asset re-downloading and enrichment registry hot-swap

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ lazy val dependencies = Seq(
     Dependencies.snowplowStreamCollector,
     Dependencies.snowplowCommonEnrich,
     Dependencies.snowplowAnalyticsSdk,
+    Dependencies.snowplowRuntime,
     Dependencies.decline,
     Dependencies.http4sCirce,
     Dependencies.http4sClient,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,13 +37,16 @@ object Dependencies {
     val azureStorageBlob = "12.25.1"
     val azureIdentity    = "1.13.3"
 
+    val snowplowRuntime = "0.20.0-M2"
+
     // force versions of transitive dependencies
     val badRows   = "2.2.0"
   }
 
-  val snowplowStreamCollector = "com.snowplowanalytics" %% "snowplow-stream-collector-http4s-core" % V.snowplowStreamCollector 
+  val snowplowStreamCollector = "com.snowplowanalytics" %% "snowplow-stream-collector-http4s-core" % V.snowplowStreamCollector
   val snowplowCommonEnrich    = "com.snowplowanalytics" %% "snowplow-common-enrich"                % V.snowplowCommonEnrich
   val snowplowAnalyticsSdk    = "com.snowplowanalytics" %% "snowplow-scala-analytics-sdk"          % V.snowplowAnalyticsSdk
+  val snowplowRuntime         = "com.snowplowanalytics" %% "runtime-common"                        % V.snowplowRuntime
   
   val http4sCirce  = "org.http4s"    %% "http4s-circe"        % V.http4sCirce
   val http4sClient = "org.http4s"    %% "http4s-ember-client" % V.http4sCirce

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   object V {
     // Snowplow
     val snowplowStreamCollector = "3.7.0"
-    val snowplowCommonEnrich    = "6.1.2"
+    val snowplowCommonEnrich    = "6.9.0"
     val snowplowAnalyticsSdk    = "3.2.0"
 
     val http4sCirce = "0.23.23"
@@ -37,7 +37,7 @@ object Dependencies {
     val azureStorageBlob = "12.25.1"
     val azureIdentity    = "1.13.3"
 
-    val snowplowRuntime = "0.20.0-M2"
+    val snowplowRuntime = "0.21.0"
 
     // force versions of transitive dependencies
     val badRows   = "2.2.0"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -74,6 +74,9 @@ object Settings {
         case dependency @ Library(module, _, _, _)
           if module.jarName.startsWith("snowplow-stream-collector") =>
           s"collector-${dependency.target}"
+        case dependency @ Library(module, _, _, _)
+          if module.jarName.startsWith("runtime-common") =>
+          s"runtime-${dependency.target}"
         case dependency => dependency.target
       }
       case x => MergeStrategy.first

--- a/src/main/resources/default-iglu-resolver.conf
+++ b/src/main/resources/default-iglu-resolver.conf
@@ -10,6 +10,7 @@
   "schema": "iglu:com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-1",
   "data": {
     "cacheSize": 500,
+    "cacheTtl": 60,
     "repositories": [
       {
         "name": "Iglu Central",

--- a/src/main/resources/enrich-micro.conf
+++ b/src/main/resources/enrich-micro.conf
@@ -1,0 +1,3 @@
+enrich {
+  assetsUpdatePeriod = "7 days"
+}

--- a/src/main/resources/enrich-micro.conf
+++ b/src/main/resources/enrich-micro.conf
@@ -1,3 +1,4 @@
 enrich {
   assetsUpdatePeriod = "7 days"
+  jsAllowedJavaClasses = ["*"]
 }

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/AssetRefresher.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/AssetRefresher.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2019-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.1
+ * located at https://docs.snowplow.io/limited-use-license-1.1
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package com.snowplowanalytics.snowplow.micro
+
+import cats.effect.{IO, Ref}
+import cats.implicits._
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.EnrichmentRegistry
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf
+import com.snowplowanalytics.snowplow.runtime.processing.Coldswap
+import fs2.Stream
+import fs2.io.file.{Files, Path}
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+import java.net.URI
+import java.nio.ByteBuffer
+import scala.concurrent.duration._
+
+object AssetRefresher {
+
+  implicit private def logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+
+  case class AssetState(uri: URI, filePath: String, etag: Option[String])
+  private case class UpdatedAsset(filePath: String, content: ByteBuffer)
+
+  def initialDownload(configs: List[EnrichmentConf]): IO[Ref[IO, List[AssetState]]] = {
+    val assets = configs.flatMap(_.filesToCache)
+    for {
+      results <- downloadAllAssets(assets.map { case (uri, path) => AssetState(uri, path, None) })
+      _ <- results.flatMap(_._2).traverse_(asset => writeToFile(asset.content, asset.filePath))
+      stateRef <- Ref.of[IO, List[AssetState]](results.map(_._1))
+    } yield stateRef
+  }
+
+  def updateStream(
+    period: FiniteDuration,
+    stateRef: Ref[IO, List[AssetState]],
+    registryColdswap: Coldswap[IO, EnrichmentRegistry[IO]]
+  ): Stream[IO, Nothing] = {
+    Stream.fixedDelay[IO](period).evalMap { _ =>
+      refreshAssets(stateRef, registryColdswap)
+        .handleErrorWith { error =>
+          logger.warn(s"Asset refresh failed, keeping existing registry: ${error.getMessage}")
+        }
+    }.drain
+  }
+
+  private def refreshAssets(
+    stateRef: Ref[IO, List[AssetState]],
+    registryColdswap: Coldswap[IO, EnrichmentRegistry[IO]]
+  ): IO[Unit] = {
+    for {
+      currentState <- stateRef.get
+      results <- downloadAllAssets(currentState)
+      updatedAssets = results.flatMap(_._2)
+      _ <- if (updatedAssets.nonEmpty) {
+        val newStates = results.map(_._1)
+        for {
+          _ <- logger.info("Asset changes detected, rebuilding enrichment registry")
+          _ <- registryColdswap.closed.surround {
+            updatedAssets.traverse_(asset => writeToFile(asset.content, asset.filePath))
+          }
+          _ <- stateRef.set(newStates)
+        } yield ()
+      } else {
+        logger.debug("No asset changes detected")
+      }
+    } yield ()
+  }
+
+  private def downloadAllAssets(assets: List[AssetState]): IO[List[(AssetState, Option[UpdatedAsset])]] = {
+    assets
+      .groupBy(asset => BlobUtils.blobClientFor(asset.uri))
+      .toList
+      .flatTraverse { case (blobClient, groupedAssets) =>
+        blobClient.mk.use { client =>
+          groupedAssets.traverse { asset =>
+            downloadSingleAsset(client, asset)
+              .handleErrorWith { error =>
+                logger.warn(s"Failed to check asset ${asset.uri}: ${error.getMessage}")
+                  .as((asset, None))
+              }
+          }
+        }
+      }
+  }
+
+  private def downloadSingleAsset(client: BlobClientImpl, asset: AssetState): IO[(AssetState, Option[UpdatedAsset])] = {
+    client.downloadIfNeeded(asset.uri, asset.etag).flatMap {
+      case Downloaded(content, newEtag) =>
+        logger.info(s"Downloaded asset: ${asset.uri} -> ${asset.filePath}")
+          .as((asset.copy(etag = newEtag), Some(UpdatedAsset(asset.filePath, content))))
+      case NotModified =>
+        IO.pure((asset, None))
+    }
+  }
+
+  private def writeToFile(content: ByteBuffer, filePath: String): IO[Unit] = {
+    Stream.chunk(fs2.Chunk.byteBuffer(content))
+      .through(Files[IO].writeAll(Path(filePath)))
+      .compile
+      .drain
+  }
+}

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/AssetRefresher.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/AssetRefresher.scala
@@ -10,16 +10,17 @@
 
 package com.snowplowanalytics.snowplow.micro
 
-import cats.effect.{IO, Ref}
+import cats.effect.{IO, Resource}
+import cats.effect.std.AtomicCell
 import cats.implicits._
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.EnrichmentRegistry
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf
 import com.snowplowanalytics.snowplow.runtime.processing.Coldswap
 import fs2.Stream
-import fs2.io.file.{Files, Path}
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
+import java.io.{FileOutputStream, OutputStream}
 import java.net.URI
 import java.nio.ByteBuffer
 import scala.concurrent.duration._
@@ -31,22 +32,34 @@ object AssetRefresher {
   case class AssetState(uri: URI, filePath: String, etag: Option[String])
   private case class UpdatedAsset(filePath: String, content: ByteBuffer)
 
-  def initialDownload(configs: List[EnrichmentConf]): IO[Ref[IO, List[AssetState]]] = {
+  def makeClients(configs: List[EnrichmentConf]): Resource[IO, Map[BlobClient, BlobClientImpl]] = {
+    val assets = configs.flatMap(_.filesToCache)
+    val blobClients = assets.map { case (uri, _) => BlobUtils.blobClientFor(uri) }.distinct
+    blobClients.traverse { bc =>
+      bc.mk.map(impl => bc -> impl)
+    }.map(_.toMap)
+  }
+
+  def initialDownload(
+    configs: List[EnrichmentConf],
+    clients: Map[BlobClient, BlobClientImpl]
+  ): IO[AtomicCell[IO, List[AssetState]]] = {
     val assets = configs.flatMap(_.filesToCache)
     for {
-      results <- downloadAllAssets(assets.map { case (uri, path) => AssetState(uri, path, None) })
+      results <- downloadAllAssets(assets.map { case (uri, path) => AssetState(uri, path, None) }, clients, tolerateErrors = false)
       _ <- results.flatMap(_._2).traverse_(asset => writeToFile(asset.content, asset.filePath))
-      stateRef <- Ref.of[IO, List[AssetState]](results.map(_._1))
-    } yield stateRef
+      atomicCell <- AtomicCell[IO].of(results.map(_._1))
+    } yield atomicCell
   }
 
   def updateStream(
     period: FiniteDuration,
-    stateRef: Ref[IO, List[AssetState]],
+    atomicCell: AtomicCell[IO, List[AssetState]],
+    clients: Map[BlobClient, BlobClientImpl],
     registryColdswap: Coldswap[IO, EnrichmentRegistry[IO]]
   ): Stream[IO, Nothing] = {
     Stream.fixedDelay[IO](period).evalMap { _ =>
-      refreshAssets(stateRef, registryColdswap)
+      refreshAssets(atomicCell, clients, registryColdswap)
         .handleErrorWith { error =>
           logger.warn(s"Asset refresh failed, keeping existing registry: ${error.getMessage}")
         }
@@ -54,41 +67,46 @@ object AssetRefresher {
   }
 
   private def refreshAssets(
-    stateRef: Ref[IO, List[AssetState]],
+    atomicCell: AtomicCell[IO, List[AssetState]],
+    clients: Map[BlobClient, BlobClientImpl],
     registryColdswap: Coldswap[IO, EnrichmentRegistry[IO]]
   ): IO[Unit] = {
-    for {
-      currentState <- stateRef.get
-      results <- downloadAllAssets(currentState)
-      updatedAssets = results.flatMap(_._2)
-      _ <- if (updatedAssets.nonEmpty) {
+    atomicCell.evalUpdate { currentState =>
+      downloadAllAssets(currentState, clients, tolerateErrors = true).flatMap { results =>
+        val updatedAssets = results.flatMap(_._2)
         val newStates = results.map(_._1)
-        for {
-          _ <- logger.info("Asset changes detected, rebuilding enrichment registry")
-          _ <- registryColdswap.closed.surround {
-            updatedAssets.traverse_(asset => writeToFile(asset.content, asset.filePath))
-          }
-          _ <- stateRef.set(newStates)
-        } yield ()
-      } else {
-        logger.debug("No asset changes detected")
+        if (updatedAssets.nonEmpty)
+          for {
+            _ <- logger.info("Asset changes detected, rebuilding enrichment registry")
+            _ <- registryColdswap.closed.surround {
+              updatedAssets.traverse_(asset => writeToFile(asset.content, asset.filePath))
+            }
+          } yield newStates
+        else
+          logger.debug("No asset changes detected").as(currentState)
       }
-    } yield ()
+    }
   }
 
-  private def downloadAllAssets(assets: List[AssetState]): IO[List[(AssetState, Option[UpdatedAsset])]] = {
+  private def downloadAllAssets(
+    assets: List[AssetState],
+    clients: Map[BlobClient, BlobClientImpl],
+    tolerateErrors: Boolean
+  ): IO[List[(AssetState, Option[UpdatedAsset])]] = {
     assets
       .groupBy(asset => BlobUtils.blobClientFor(asset.uri))
       .toList
       .flatTraverse { case (blobClient, groupedAssets) =>
-        blobClient.mk.use { client =>
-          groupedAssets.traverse { asset =>
-            downloadSingleAsset(client, asset)
-              .handleErrorWith { error =>
-                logger.warn(s"Failed to check asset ${asset.uri}: ${error.getMessage}")
-                  .as((asset, None))
-              }
-          }
+        val client = clients(blobClient)
+        groupedAssets.traverse { asset =>
+          val download = downloadSingleAsset(client, asset)
+          if (tolerateErrors)
+            download.handleErrorWith { error =>
+              logger.warn(s"Failed to check asset ${asset.uri}: ${error.getMessage}")
+                .as((asset, None))
+            }
+          else
+            download
         }
       }
   }
@@ -103,10 +121,10 @@ object AssetRefresher {
     }
   }
 
-  private def writeToFile(content: ByteBuffer, filePath: String): IO[Unit] = {
-    Stream.chunk(fs2.Chunk.byteBuffer(content))
-      .through(Files[IO].writeAll(Path(filePath)))
+  private def writeToFile(content: ByteBuffer, filePath: String): IO[Unit] =
+    Stream
+      .chunk(fs2.Chunk.byteBuffer(content))
+      .through(fs2.io.writeOutputStream(IO.blocking[OutputStream](new FileOutputStream(filePath))))
       .compile
       .drain
-  }
 }

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/BlobUtils.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/BlobUtils.scala
@@ -13,16 +13,17 @@ package com.snowplowanalytics.snowplow.micro
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.model.{GetObjectRequest, GetObjectResponse}
 import software.amazon.awssdk.core.async.AsyncResponseTransformer
-import com.google.cloud.storage.{StorageOptions, BlobId}
+import com.google.cloud.storage.{Storage, StorageOptions, BlobId}
+import com.azure.core.http.HttpHeaderName
 import com.azure.storage.blob.{BlobServiceAsyncClient, BlobServiceClientBuilder, BlobUrlParts}
+import com.azure.storage.blob.models.{BlobRequestConditions, BlobStorageException}
 
 import java.nio.ByteBuffer
 import cats.effect.{IO, Resource, Sync}
 import cats.implicits._
 import com.azure.identity.DefaultAzureCredentialBuilder
 import com.snowplowanalytics.snowplow.micro.Configuration.EnvironmentVariables
-import fs2.{Stream, Chunk}
-import fs2.io.file.{Files, Path}
+
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.{Method, Request, Status, Uri}
 import software.amazon.awssdk.awscore.defaultsmode.DefaultsMode
@@ -107,9 +108,11 @@ case object GCSClient extends BlobClient {
             val remoteEtag = Option(blob.getEtag)
             if (currentEtag.isDefined && currentEtag == remoteEtag)
               IO.pure(NotModified: DownloadResult)
-            else
-              Sync[IO].blocking(service.readAllBytes(blobId))
+            else {
+              val generation = blob.getGeneration
+              Sync[IO].blocking(service.readAllBytes(blobId, Storage.BlobSourceOption.generationMatch(generation)))
                 .map(bytes => Downloaded(ByteBuffer.wrap(bytes), remoteEtag): DownloadResult)
+            }
           case None =>
             IO.raiseError(new RuntimeException(s"Blob not found: $uri"))
         }
@@ -131,16 +134,16 @@ case class AzureClient(account: String) extends BlobClient {
           .getBlobContainerAsyncClient(inputParts.getBlobContainerName)
           .getBlobAsyncClient(inputParts.getBlobName)
 
+        val conditions = currentEtag.map(etag => new BlobRequestConditions().setIfNoneMatch(etag)).orNull
+
         Sync[IO].fromCompletableFuture(
-          Sync[IO].delay(blobClient.getProperties.toFuture)
-        ).flatMap { props =>
-          val remoteEtag = Option(props.getETag)
-          if (currentEtag.isDefined && currentEtag == remoteEtag)
-            IO.pure(NotModified: DownloadResult)
-          else
-            Sync[IO].fromCompletableFuture(
-              Sync[IO].delay(blobClient.downloadContent().toFuture)
-            ).map(binaryData => Downloaded(binaryData.toByteBuffer, remoteEtag): DownloadResult)
+          Sync[IO].delay(blobClient.downloadContentWithResponse(null, conditions).toFuture)
+        ).map { response =>
+          val remoteEtag = Option(response.getHeaders.getValue(HttpHeaderName.ETAG))
+          Downloaded(response.getValue.toByteBuffer, remoteEtag): DownloadResult
+        }.recover {
+          case e: BlobStorageException if e.getStatusCode == 304 =>
+            NotModified: DownloadResult
         }
       }
 

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/BlobUtils.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/BlobUtils.scala
@@ -49,36 +49,46 @@ object BlobUtils {
 
 /* Adapted and simplified from Enrich. TODO: Make Micro into an Enrich app and remove this. */
 
+sealed trait DownloadResult
+case class Downloaded(content: ByteBuffer, etag: Option[String]) extends DownloadResult
+case object NotModified extends DownloadResult
+
 sealed trait BlobClient {
   def mk: Resource[IO, BlobClientImpl]
 }
 
-class BlobClientImpl(download: URI => IO[ByteBuffer]) {
-  def downloadToFiles(uriFilePairs: List[(URI, String)]): IO[Unit] = {
-    uriFilePairs.traverse_ { case (uri, filePath) =>
-      download(uri).flatMap { buffer =>
-        Stream.chunk(Chunk.byteBuffer(buffer))
-          .through(Files[IO].writeAll(Path(filePath)))
-          .compile
-          .drain
-      }
-    }
-  }
+class BlobClientImpl(
+  download: (URI, Option[String]) => IO[DownloadResult]
+) {
+  def downloadIfNeeded(uri: URI, currentEtag: Option[String]): IO[DownloadResult] =
+    download(uri, currentEtag)
 }
 
 case object S3Client extends BlobClient {
   override def mk: Resource[IO, BlobClientImpl] = {
     for {
       s3Client <- Resource.fromAutoCloseable(Sync[IO].delay(S3AsyncClient.builder().defaultsMode(DefaultsMode.AUTO).build()))
-    } yield new BlobClientImpl(uri => {
-      val bucket = uri.getHost
-      val key = uri.getPath.stripPrefix("/")
-      val request = GetObjectRequest.builder().bucket(bucket).key(key).build()
+    } yield {
+      val download: (URI, Option[String]) => IO[DownloadResult] = (uri, currentEtag) => {
+        val bucket = uri.getHost
+        val key = uri.getPath.stripPrefix("/")
+        val builder = GetObjectRequest.builder().bucket(bucket).key(key)
+        currentEtag.foreach(etag => builder.ifNoneMatch(etag))
+        val request = builder.build()
 
-      Sync[IO].fromCompletableFuture(
-        Sync[IO].delay(s3Client.getObject(request, AsyncResponseTransformer.toBytes[GetObjectResponse]()))
-      ).map(response => ByteBuffer.wrap(response.asByteArrayUnsafe()))
-    })
+        Sync[IO].fromCompletableFuture(
+          Sync[IO].delay(s3Client.getObject(request, AsyncResponseTransformer.toBytes[GetObjectResponse]()))
+        ).map { response =>
+          val etag = Option(response.response().eTag())
+          Downloaded(ByteBuffer.wrap(response.asByteArrayUnsafe()), etag): DownloadResult
+        }.recover {
+          case e: software.amazon.awssdk.services.s3.model.S3Exception if e.statusCode() == 304 =>
+            NotModified: DownloadResult
+        }
+      }
+
+      new BlobClientImpl(download)
+    }
   }
 }
 
@@ -86,14 +96,27 @@ case object GCSClient extends BlobClient {
   override def mk: Resource[IO, BlobClientImpl] = {
     for {
       service <- Resource.fromAutoCloseable(Sync[IO].delay(StorageOptions.getDefaultInstance.getService))
-    } yield new BlobClientImpl(uri => {
-      val bucket = uri.getHost
-      val blobName = uri.getPath.stripPrefix("/")
-      val blobId = BlobId.of(bucket, blobName)
+    } yield {
+      val download: (URI, Option[String]) => IO[DownloadResult] = (uri, currentEtag) => {
+        val bucket = uri.getHost
+        val blobName = uri.getPath.stripPrefix("/")
+        val blobId = BlobId.of(bucket, blobName)
 
-      Sync[IO].blocking(service.readAllBytes(blobId))
-        .map(ByteBuffer.wrap)
-    })
+        Sync[IO].blocking(Option(service.get(blobId))).flatMap {
+          case Some(blob) =>
+            val remoteEtag = Option(blob.getEtag)
+            if (currentEtag.isDefined && currentEtag == remoteEtag)
+              IO.pure(NotModified: DownloadResult)
+            else
+              Sync[IO].blocking(service.readAllBytes(blobId))
+                .map(bytes => Downloaded(ByteBuffer.wrap(bytes), remoteEtag): DownloadResult)
+          case None =>
+            IO.raiseError(new RuntimeException(s"Blob not found: $uri"))
+        }
+      }
+
+      new BlobClientImpl(download)
+    }
   }
 }
 
@@ -101,16 +124,28 @@ case class AzureClient(account: String) extends BlobClient {
   override def mk: Resource[IO, BlobClientImpl] = {
     for {
       client <- Resource.eval(createAzureClient(account))
-    } yield new BlobClientImpl(uri => {
-      val inputParts = BlobUrlParts.parse(uri.toString)
-      val blobClient = client
-        .getBlobContainerAsyncClient(inputParts.getBlobContainerName)
-        .getBlobAsyncClient(inputParts.getBlobName)
+    } yield {
+      val download: (URI, Option[String]) => IO[DownloadResult] = (uri, currentEtag) => {
+        val inputParts = BlobUrlParts.parse(uri.toString)
+        val blobClient = client
+          .getBlobContainerAsyncClient(inputParts.getBlobContainerName)
+          .getBlobAsyncClient(inputParts.getBlobName)
 
-      Sync[IO].fromCompletableFuture(
-        Sync[IO].delay(blobClient.downloadContent().toFuture)
-      ).map(binaryData => binaryData.toByteBuffer)
-    })
+        Sync[IO].fromCompletableFuture(
+          Sync[IO].delay(blobClient.getProperties.toFuture)
+        ).flatMap { props =>
+          val remoteEtag = Option(props.getETag)
+          if (currentEtag.isDefined && currentEtag == remoteEtag)
+            IO.pure(NotModified: DownloadResult)
+          else
+            Sync[IO].fromCompletableFuture(
+              Sync[IO].delay(blobClient.downloadContent().toFuture)
+            ).map(binaryData => Downloaded(binaryData.toByteBuffer, remoteEtag): DownloadResult)
+        }
+      }
+
+      new BlobClientImpl(download)
+    }
   }
 
   private def createAzureClient(account: String): IO[BlobServiceAsyncClient] = {
@@ -136,18 +171,26 @@ case class AzureClient(account: String) extends BlobClient {
 case object Http extends BlobClient {
   override def mk: Resource[IO, BlobClientImpl] = {
     EmberClientBuilder.default[IO].build.map { httpClient =>
-      new BlobClientImpl(uri => {
-        val request = Request[IO](Method.GET, Uri.unsafeFromString(uri.toString))
+      val download: (URI, Option[String]) => IO[DownloadResult] = (uri, currentEtag) => {
+        val etagHeaders = currentEtag.toList.map(etag =>
+          org.http4s.Header.Raw(org.typelevel.ci.CIString("If-None-Match"), etag)
+        )
+        val request = Request[IO](Method.GET, Uri.unsafeFromString(uri.toString), headers = org.http4s.Headers(etagHeaders))
 
         httpClient.run(request).use { response =>
           response.status match {
             case Status.Ok =>
-              response.body.compile.to(Array).map(ByteBuffer.wrap)
+              val etag = response.headers.get(org.typelevel.ci.CIString("ETag")).map(_.head.value)
+              response.body.compile.to(Array).map(bytes => Downloaded(ByteBuffer.wrap(bytes), etag): DownloadResult)
+            case Status.NotModified =>
+              IO.pure(NotModified: DownloadResult)
             case status =>
               IO.raiseError(new RuntimeException(s"Failed to download $uri: ${status.code} ${status.reason}"))
           }
         }
-      })
+      }
+
+      new BlobClientImpl(download)
     }
   }
 }

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/Configuration.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/Configuration.scala
@@ -34,7 +34,6 @@ import io.circe.{Decoder, Json, JsonObject}
 import org.http4s.Uri
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
-
 import java.net.URI
 import java.nio.file.{Path, Paths}
 import scala.concurrent.duration.FiniteDuration
@@ -66,7 +65,7 @@ object Configuration {
       Uri.fromString(str).leftMap(_ => s"Invalid URI: $str").toValidatedNel
     }
 
-    final case class Config(collector: Option[Path],
+    final case class Config(collectorAndEnrich: Option[Path],
                             iglu: Option[Path],
                             outputFormat: OutputFormat,
                             destination: Option[Uri],
@@ -74,7 +73,10 @@ object Configuration {
                             storage: StorageMode,
                             auth: Option[Path])
 
-    private val collector = Opts.option[Path]("collector-config", "Configuration file for Collector", "c", "config.hocon").orNone
+    private val collectorAndEnrich = (
+      Opts.option[Path]("collector-config", "Configuration file for Collector (alias for --config)", metavar = "config.hocon") orElse
+      Opts.option[Path]("config", "Configuration file for Collector and Enrich", "c", "config.hocon")
+    ).orNone
     private val iglu = Opts.option[Path]("iglu", "Configuration file for Iglu Client", "i", "iglu.json").orNone
     private val outputTsv = Opts.flag("output-tsv", "Output events in TSV format to standard output or HTTP destination", "t").orFalse
     private val outputJson = Opts.flag("output-json", "Output events in JSON format to standard output or HTTP destination (with a separate key for each schema)", "j").orFalse
@@ -105,7 +107,7 @@ object Configuration {
           parseStorageConfig(path)
       }
 
-    val config: Opts[Config] = (collector, iglu, output, yauaa, storageConfig, auth).mapN {
+    val config: Opts[Config] = (collectorAndEnrich, iglu, output, yauaa, storageConfig, auth).mapN {
       case (c, i, (f, d), y, s, a) => Config(c, i, f, d, y, s, a)
     }
   }
@@ -151,7 +153,8 @@ object Configuration {
   final case class EnrichConfig(
     adaptersSchemas: EnrichAdaptersSchemas,
     maxJsonDepth: Int,
-    validation: EnrichValidation
+    validation: EnrichValidation,
+    assetsUpdatePeriod: FiniteDuration
   )
 
   final case class IgluResources(resolver: Resolver[IO], client: IgluCirceClient[IO])
@@ -195,8 +198,8 @@ object Configuration {
   def load(): Opts[EitherT[IO, String, MicroConfig]] = {
     Cli.config.map { cliConfig =>
       for {
-        collectorConfig <- loadCollectorConfig(cliConfig.collector)
-        enrichConfig <- loadEnrichConfig()
+        collectorConfig <- loadCollectorConfig(cliConfig.collectorAndEnrich)
+        enrichConfig <- loadEnrichConfig(cliConfig.collectorAndEnrich)
         igluResources <- loadIgluResources(cliConfig.iglu, enrichConfig.maxJsonDepth)
         enrichmentsConfig <- loadEnrichmentConfig(igluResources.client, cliConfig.yauaa)
         authConfig <- loadAuthConfig(cliConfig.auth)
@@ -209,9 +212,9 @@ object Configuration {
 
   private def loadCollectorConfig(path: Option[Path]): EitherT[IO, String, CollectorConfig[SinkConfig]] = {
     val resolveOrder = (config: TypesafeConfig) =>
-      namespaced(ConfigFactory.load(
-        namespaced(config.withFallback(
-          namespaced(ConfigFactory.parseResources("collector-micro.conf")
+      collectorNamespaced(ConfigFactory.load(
+        collectorNamespaced(config.withFallback(
+          collectorNamespaced(ConfigFactory.parseResources("collector-micro.conf")
             // collector-reference.conf only exists in fat jars
             // in Docker or sbt run, the fallback is correctly placed in the Collector jar
             .withFallback(ConfigFactory.parseResources("collector-reference.conf"))
@@ -263,11 +266,15 @@ object Configuration {
     }
   }
 
-  def loadEnrichConfig(): EitherT[IO, String, EnrichConfig] = {
-    val resolveOrder = (config: TypesafeConfig) => ConfigFactory.load(config)
+  def loadEnrichConfig(configPath: Option[Path]): EitherT[IO, String, EnrichConfig] = {
+    val resolveOrder = (config: TypesafeConfig) =>
+      enrichNamespaced(ConfigFactory.load(
+        enrichNamespaced(config.withFallback(
+          enrichNamespaced(ConfigFactory.parseResources("enrich-micro.conf"))
+        ))
+      ))
 
-    //It's not configurable in micro, we load it from reference.conf provided by enrich
-    loadConfig[EnrichConfig](path = None, resolveOrder)
+    loadConfig[EnrichConfig](configPath, resolveOrder)
   }
 
   private def loadAuthConfig(authConfigPath: Option[Path]): EitherT[IO, String, Option[AuthConfig]] = {
@@ -377,13 +384,15 @@ object Configuration {
     }
   }
 
-  private def namespaced(config: TypesafeConfig): TypesafeConfig = {
-    val namespace = "collector"
+  private def namespaced(config: TypesafeConfig, namespace: String): TypesafeConfig = {
     if (config.hasPath(namespace))
       config.getConfig(namespace).withFallback(config.withoutPath(namespace))
     else
       config
   }
+
+  private def collectorNamespaced(config: TypesafeConfig) = namespaced(config, "collector")
+  private def enrichNamespaced(config: TypesafeConfig) = namespaced(config, "enrich")
 
   implicit val resolverDecoder: Decoder[ResolverConfig] = Decoder.decodeJson.emap(json => Resolver.parseConfig(json).leftMap(_.show))
 

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/Configuration.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/Configuration.scala
@@ -154,7 +154,8 @@ object Configuration {
     adaptersSchemas: EnrichAdaptersSchemas,
     maxJsonDepth: Int,
     validation: EnrichValidation,
-    assetsUpdatePeriod: FiniteDuration
+    assetsUpdatePeriod: FiniteDuration,
+    jsAllowedJavaClasses: Set[String]
   )
 
   final case class IgluResources(resolver: Resolver[IO], client: IgluCirceClient[IO])

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/EventSink.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/EventSink.scala
@@ -10,7 +10,7 @@
 
 package com.snowplowanalytics.snowplow.micro
 
-import cats.data.{NonEmptyList, Validated}
+import cats.data.Validated
 import cats.effect.IO
 import cats.implicits._
 import com.snowplowanalytics.iglu.client.IgluCirceClient
@@ -24,7 +24,8 @@ import com.snowplowanalytics.snowplow.enrich.common.adapters.{AdapterRegistry, R
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.{EnrichmentManager, EnrichmentRegistry}
 import com.snowplowanalytics.snowplow.runtime.processing.Coldswap
 import com.snowplowanalytics.snowplow.enrich.common.loaders.ThriftLoader
-import com.snowplowanalytics.snowplow.enrich.common.utils.{ConversionUtils, OptionIor, OptionIorT}
+import com.snowplowanalytics.snowplow.enrich.common.outputs.EnrichedEvent
+import com.snowplowanalytics.snowplow.enrich.common.utils.{ConversionUtils, OptionIor}
 import io.circe.syntax._
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
@@ -100,7 +101,7 @@ final class EventSink(igluClient: IgluCirceClient[IO],
           case Validated.Valid(rawEvents) =>
             rawEvents.toList.foldLeftM((Nil, Nil): (List[GoodEvent], List[BadEvent])) {
               case ((good, bad), rawEvent) =>
-                validateEvent(rawEvent).value.map {
+                validateEvent(rawEvent).map {
                   case OptionIor.Right(goodEvent) =>
                     logger.info(s"GOOD ${formatEvent(goodEvent)}")
                     (goodEvent :: good, bad)
@@ -132,8 +133,8 @@ final class EventSink(igluClient: IgluCirceClient[IO],
    * @return [[GoodEvent]] with the extracted event type, schema and contexts,
    *   or error if the event couldn't be validated.
    */
-  private[micro] def validateEvent(rawEvent: RawEvent): OptionIorT[IO, (List[String], BadRow), GoodEvent] =
-    OptionIorT(registryColdswap.opened.use { enrichmentRegistry =>
+  private[micro] def validateEvent(rawEvent: RawEvent): IO[OptionIor[(List[String], BadRow), GoodEvent]] =
+    registryColdswap.opened.use { enrichmentRegistry =>
       EnrichmentManager.enrichEvent[IO](
           enrichmentRegistry,
           igluClient,
@@ -144,30 +145,33 @@ final class EventSink(igluClient: IgluCirceClient[IO],
           IO.unit,
           registryLookup,
           enrichConfig.validation.atomicFieldsLimits,
-          emitIncomplete = true,
+          emitFailed = true,
           enrichConfig.maxJsonDepth
-        )
-      .leftMap(NonEmptyList.one(_)) // Because the following `.flatMap requires a SemiGroup on the Left
-      .flatMap { enriched =>
-        val ior: OptionIor[NonEmptyList[BadRow], Event] = EventConverter.fromEnriched(enriched) match {
-          case Validated.Valid(converted) =>
-            OptionIor.Right(converted)
-          case Validated.Invalid(failure) =>
-            val badRow = BadRow.LoaderParsingError(processor, failure, Payload.RawPayload(ConversionUtils.tabSeparatedEnrichedEvent(enriched)))
-            OptionIor.Left(NonEmptyList.one(badRow))
+        ).map { result =>
+
+          def validateToGoodEvent(enriched: EnrichedEvent): Validated[BadRow, GoodEvent] =
+            EventConverter.fromEnriched(enriched) match {
+              case Validated.Valid(converted) =>
+                Validated.Valid(GoodEvent(rawEvent, converted.event, getEnrichedSchema(converted), getEnrichedContexts(converted), converted))
+              case Validated.Invalid(failure) =>
+                Validated.Invalid(BadRow.LoaderParsingError(processor, failure, Payload.RawPayload(ConversionUtils.tabSeparatedEnrichedEvent(enriched))))
+            }
+
+          def badResult(badRows: List[BadRow]): (List[String], BadRow) =
+            ("Error while validating the event." :: badRows.map(_.compact), badRows.head)
+
+          result match {
+            case OptionIor.Left(badRow) =>
+              OptionIor.Left(badResult(List(badRow)))
+            case OptionIor.Right(enriched) =>
+              validateToGoodEvent(enriched).fold(br => OptionIor.Left(badResult(List(br))), OptionIor.Right(_))
+            case OptionIor.Both(badRow1, enriched) =>
+              validateToGoodEvent(enriched).fold(br => OptionIor.Left(badResult(List(badRow1, br))), OptionIor.Right(_))
+            case OptionIor.None =>
+              OptionIor.None
+          }
         }
-        OptionIorT(IO.pure(ior))
-      }
-      .map { enriched =>
-        GoodEvent(rawEvent, enriched.event, getEnrichedSchema(enriched), getEnrichedContexts(enriched), enriched)
-      }
-      .leftMap { nel =>
-        // We can ignore the .tail of this non-emoty-list because we only expect a single bad row
-        val badRow = nel.head
-        (List("Error while validating the event.", badRow.compact), badRow)
-      }
-      .value
-    })
+    }
 
   private def getEnrichedSchema(enriched: Event): Option[String] =
     List(enriched.event_vendor, enriched.event_name, enriched.event_format, enriched.event_version)

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/EventSink.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/EventSink.scala
@@ -22,6 +22,7 @@ import com.snowplowanalytics.snowplow.collector.core.Sink
 import com.snowplowanalytics.snowplow.enrich.common.EtlPipeline
 import com.snowplowanalytics.snowplow.enrich.common.adapters.{AdapterRegistry, RawEvent}
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.{EnrichmentManager, EnrichmentRegistry}
+import com.snowplowanalytics.snowplow.runtime.processing.Coldswap
 import com.snowplowanalytics.snowplow.enrich.common.loaders.ThriftLoader
 import com.snowplowanalytics.snowplow.enrich.common.utils.{ConversionUtils, OptionIor, OptionIorT}
 import io.circe.syntax._
@@ -44,7 +45,7 @@ import java.time.Instant
  */
 final class EventSink(igluClient: IgluCirceClient[IO],
                       registryLookup: RegistryLookup[IO],
-                      enrichmentRegistry: EnrichmentRegistry[IO],
+                      registryColdswap: Coldswap[IO, EnrichmentRegistry[IO]],
                       outputFormat: OutputFormat,
                       destination: Option[Uri],
                       processor: Processor,
@@ -132,19 +133,20 @@ final class EventSink(igluClient: IgluCirceClient[IO],
    *   or error if the event couldn't be validated.
    */
   private[micro] def validateEvent(rawEvent: RawEvent): OptionIorT[IO, (List[String], BadRow), GoodEvent] =
-    EnrichmentManager.enrichEvent[IO](
-        enrichmentRegistry,
-        igluClient,
-        processor,
-        DateTime.now(),
-        rawEvent,
-        EtlPipeline.FeatureFlags(acceptInvalid = false),
-        IO.unit,
-        registryLookup,
-        enrichConfig.validation.atomicFieldsLimits,
-        emitIncomplete = true,
-        enrichConfig.maxJsonDepth
-      )
+    OptionIorT(registryColdswap.opened.use { enrichmentRegistry =>
+      EnrichmentManager.enrichEvent[IO](
+          enrichmentRegistry,
+          igluClient,
+          processor,
+          DateTime.now(),
+          rawEvent,
+          EtlPipeline.FeatureFlags(acceptInvalid = false),
+          IO.unit,
+          registryLookup,
+          enrichConfig.validation.atomicFieldsLimits,
+          emitIncomplete = true,
+          enrichConfig.maxJsonDepth
+        )
       .leftMap(NonEmptyList.one(_)) // Because the following `.flatMap requires a SemiGroup on the Left
       .flatMap { enriched =>
         val ior: OptionIor[NonEmptyList[BadRow], Event] = EventConverter.fromEnriched(enriched) match {
@@ -164,6 +166,8 @@ final class EventSink(igluClient: IgluCirceClient[IO],
         val badRow = nel.head
         (List("Error while validating the event.", badRow.compact), badRow)
       }
+      .value
+    })
 
   private def getEnrichedSchema(enriched: Event): Option[String] =
     List(enriched.event_vendor, enriched.event_name, enriched.event_format, enriched.event_version)

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/EventSink.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/EventSink.scala
@@ -166,7 +166,11 @@ final class EventSink(igluClient: IgluCirceClient[IO],
             case OptionIor.Right(enriched) =>
               validateToGoodEvent(enriched).fold(br => OptionIor.Left(badResult(List(br))), OptionIor.Right(_))
             case OptionIor.Both(badRow1, enriched) =>
-              validateToGoodEvent(enriched).fold(br => OptionIor.Left(badResult(List(badRow1, br))), OptionIor.Right(_))
+              validateToGoodEvent(enriched)
+                .fold(
+                  br => OptionIor.Left(badResult(List(badRow1, br))),
+                  ve => OptionIor.Both(badResult(List(badRow1)), ve)
+                )
             case OptionIor.None =>
               OptionIor.None
           }

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/Run.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/Run.scala
@@ -58,7 +58,7 @@ object Run {
       httpClient <- EmberClientBuilder.default[IO].build
       sqlEC <- SqlExecutionContext.mk[IO]
       assetStateRef <- Resource.eval(AssetRefresher.initialDownload(config.enrichmentsConfig))
-      registryResource = enrichmentRegistryResource(config.enrichmentsConfig, httpClient, sqlEC)
+      registryResource = enrichmentRegistryResource(config.enrichmentsConfig, httpClient, sqlEC, config.enrichConfig.jsAllowedJavaClasses)
       registryColdswap <- Coldswap.make(registryResource)
       _ <- Resource.eval(registryColdswap.opened.use_)
       badProcessor = Processor(BuildInfo.name, BuildInfo.version)
@@ -116,13 +116,11 @@ object Run {
     }
   }
 
-  // TODO: Make this configurable
-  val jsAllowedJavaClasses = Set.empty[String]
-
   private def enrichmentRegistryResource(
     configs: List[EnrichmentConf],
     httpClient: Client[IO],
-    sqlEC: ExecutionContext
+    sqlEC: ExecutionContext,
+    jsAllowedJavaClasses: Set[String]
   ): Resource[IO, EnrichmentRegistry[IO]] = {
     val enrichHttpClient = HttpClient.fromHttp4sClient[IO](httpClient)
     for {

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/Run.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/Run.scala
@@ -25,6 +25,7 @@ import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.{Enrich
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.sqlquery.SqlExecutionContext
 import com.snowplowanalytics.snowplow.enrich.common.utils.HttpClient
 import com.snowplowanalytics.snowplow.micro.Configuration.MicroConfig
+import com.snowplowanalytics.snowplow.runtime.processing.Coldswap
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.client.Client
 import org.typelevel.log4cats.Logger
@@ -32,6 +33,7 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import java.security.{KeyStore, SecureRandom}
 import javax.net.ssl.{KeyManagerFactory, SSLContext, TrustManagerFactory}
+import scala.concurrent.ExecutionContext
 
 object Run {
 
@@ -54,14 +56,24 @@ object Run {
     for {
       sslContext <- Resource.eval(setupSSLContext())
       httpClient <- EmberClientBuilder.default[IO].build
-      enrichmentRegistry <- buildEnrichmentRegistry(config.enrichmentsConfig, httpClient)
+      ipLookupEC <- IpLookupExecutionContext.mk[IO]
+      sqlEC <- SqlExecutionContext.mk[IO]
+      assetStateRef <- Resource.eval(AssetRefresher.initialDownload(config.enrichmentsConfig))
+      registryResource = enrichmentRegistryResource(config.enrichmentsConfig, httpClient, ipLookupEC, sqlEC)
+      registryColdswap <- Coldswap.make(registryResource)
+      _ <- Resource.eval(registryColdswap.opened.use_)
       badProcessor = Processor(BuildInfo.name, BuildInfo.version)
       lookup = JavaNetRegistryLookup.ioLookupInstance[IO]
       queue <- Resource.eval(Queue.unbounded[IO, CollectorPayload])
       storage <- EventStorage.create(config.storage)
       microRoutes = Routing.create(config, storage, config.auth, lookup)
-      sink = new EventSink(config.iglu.client, lookup, enrichmentRegistry, config.outputFormat, config.destination, badProcessor, config.enrichConfig, httpClient, storage)
+      sink = new EventSink(config.iglu.client, lookup, registryColdswap, config.outputFormat, config.destination, badProcessor, config.enrichConfig, httpClient, storage)
       sinks = Sinks(sink, sink)
+      _ <- AssetRefresher
+        .updateStream(config.enrichConfig.assetsUpdatePeriod, assetStateRef, registryColdswap)
+        .compile
+        .drain
+        .background
       _ <- Sinks
         .dequeue(config.collector, BuildInfo, queue, sinks)
         .compile
@@ -105,12 +117,14 @@ object Run {
     }
   }
 
-  private def buildEnrichmentRegistry(configs: List[EnrichmentConf], httpClient: Client[IO]): Resource[IO, EnrichmentRegistry[IO]] = {
+  private def enrichmentRegistryResource(
+    configs: List[EnrichmentConf],
+    httpClient: Client[IO],
+    ipLookupEC: ExecutionContext,
+    sqlEC: ExecutionContext
+  ): Resource[IO, EnrichmentRegistry[IO]] = {
+    val enrichHttpClient = HttpClient.fromHttp4sClient[IO](httpClient)
     for {
-      _ <- Resource.eval(downloadAssets(configs))
-      ipLookupEC <- IpLookupExecutionContext.mk[IO]
-      sqlEC <- SqlExecutionContext.mk[IO]
-      enrichHttpClient = HttpClient.fromHttp4sClient[IO](httpClient)
       enrichmentRegistry <- Resource.eval(EnrichmentRegistry.build[IO](configs, enrichHttpClient, ipLookupEC, sqlEC, false)
         .leftMap(error => new IllegalArgumentException(s"can't build EnrichmentRegistry: $error"))
         .value.rethrow)
@@ -124,20 +138,7 @@ object Run {
           logger.info(s"No enrichments enabled")
         }
       }
-
     } yield enrichmentRegistry
-  }
-
-  private def downloadAssets(configs: List[EnrichmentConf]): IO[Unit] = {
-    configs
-      .flatMap(_.filesToCache)
-      .groupBy {
-        case (uri, _) => BlobUtils.blobClientFor(uri)
-      }
-      .toList
-      .traverse_ {
-        case (client, assets) => client.mk.use(_.downloadToFiles(assets))
-      }
   }
 
   private def handleAppErrors(appOutput: EitherT[IO, String, ExitCode]): IO[ExitCode] = {

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/Run.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/Run.scala
@@ -21,7 +21,7 @@ import com.snowplowanalytics.snowplow.collector.core._
 import com.snowplowanalytics.snowplow.collector.core.Sinks
 import com.snowplowanalytics.snowplow.collector.thrift.CollectorPayload
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.EnrichmentRegistry
-import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.{Enrichment, EnrichmentConf, IpLookupExecutionContext}
+import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.EnrichmentConf
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.sqlquery.SqlExecutionContext
 import com.snowplowanalytics.snowplow.enrich.common.utils.HttpClient
 import com.snowplowanalytics.snowplow.micro.Configuration.MicroConfig
@@ -56,10 +56,9 @@ object Run {
     for {
       sslContext <- Resource.eval(setupSSLContext())
       httpClient <- EmberClientBuilder.default[IO].build
-      ipLookupEC <- IpLookupExecutionContext.mk[IO]
       sqlEC <- SqlExecutionContext.mk[IO]
       assetStateRef <- Resource.eval(AssetRefresher.initialDownload(config.enrichmentsConfig))
-      registryResource = enrichmentRegistryResource(config.enrichmentsConfig, httpClient, ipLookupEC, sqlEC)
+      registryResource = enrichmentRegistryResource(config.enrichmentsConfig, httpClient, sqlEC)
       registryColdswap <- Coldswap.make(registryResource)
       _ <- Resource.eval(registryColdswap.opened.use_)
       badProcessor = Processor(BuildInfo.name, BuildInfo.version)
@@ -117,20 +116,22 @@ object Run {
     }
   }
 
+  // TODO: Make this configurable
+  val jsAllowedJavaClasses = Set.empty[String]
+
   private def enrichmentRegistryResource(
     configs: List[EnrichmentConf],
     httpClient: Client[IO],
-    ipLookupEC: ExecutionContext,
     sqlEC: ExecutionContext
   ): Resource[IO, EnrichmentRegistry[IO]] = {
     val enrichHttpClient = HttpClient.fromHttp4sClient[IO](httpClient)
     for {
-      enrichmentRegistry <- Resource.eval(EnrichmentRegistry.build[IO](configs, enrichHttpClient, ipLookupEC, sqlEC, false)
+      enrichmentRegistry <- Resource.eval(EnrichmentRegistry.build[IO](configs, enrichHttpClient, sqlEC, false, jsAllowedJavaClasses)
         .leftMap(error => new IllegalArgumentException(s"can't build EnrichmentRegistry: $error"))
         .value.rethrow)
       _ <- Resource.eval {
         val loadedEnrichments = enrichmentRegistry.productIterator.toList.collect {
-          case Some(e: Enrichment) => e.getClass.getSimpleName
+          case Some(e) => e.getClass.getSimpleName
         }
         if (loadedEnrichments.nonEmpty) {
           logger.info(s"Enabled enrichments: ${loadedEnrichments.mkString(", ")}")

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/Run.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/Run.scala
@@ -57,7 +57,8 @@ object Run {
       sslContext <- Resource.eval(setupSSLContext())
       httpClient <- EmberClientBuilder.default[IO].build
       sqlEC <- SqlExecutionContext.mk[IO]
-      assetStateRef <- Resource.eval(AssetRefresher.initialDownload(config.enrichmentsConfig))
+      clients <- AssetRefresher.makeClients(config.enrichmentsConfig)
+      assetStateRef <- Resource.eval(AssetRefresher.initialDownload(config.enrichmentsConfig, clients))
       registryResource = enrichmentRegistryResource(config.enrichmentsConfig, httpClient, sqlEC, config.enrichConfig.jsAllowedJavaClasses)
       registryColdswap <- Coldswap.make(registryResource)
       _ <- Resource.eval(registryColdswap.opened.use_)
@@ -69,7 +70,7 @@ object Run {
       sink = new EventSink(config.iglu.client, lookup, registryColdswap, config.outputFormat, config.destination, badProcessor, config.enrichConfig, httpClient, storage)
       sinks = Sinks(sink, sink)
       _ <- AssetRefresher
-        .updateStream(config.enrichConfig.assetsUpdatePeriod, assetStateRef, registryColdswap)
+        .updateStream(config.enrichConfig.assetsUpdatePeriod, assetStateRef, clients, registryColdswap)
         .compile
         .drain
         .background

--- a/src/test/scala/com.snowplowanalytics.snowplow.micro/EventSinkSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.micro/EventSinkSpec.scala
@@ -25,6 +25,7 @@ import com.snowplowanalytics.snowplow.enrich.common.enrichments.EnrichmentRegist
 import com.snowplowanalytics.snowplow.enrich.common.enrichments.registry.JavascriptScriptEnrichment
 import com.snowplowanalytics.snowplow.enrich.common.utils.OptionIor
 import com.snowplowanalytics.snowplow.micro.Configuration.OutputFormat
+import com.snowplowanalytics.snowplow.runtime.processing.Coldswap
 import org.specs2.mutable.SpecificationLike
 
 import scala.io.Source
@@ -163,15 +164,16 @@ class EventSinkSpec extends CatsResource[IO, EventSink] with SpecificationLike {
 
   private def createSink(): Resource[IO, EventSink] = {
     for {
-      enrichConfig <- Resource.eval(Configuration.loadEnrichConfig().value.map(_.getOrElse(throw new IllegalArgumentException("Can't read defaults from Enrich config"))))
+      enrichConfig <- Resource.eval(Configuration.loadEnrichConfig(None).value.map(_.getOrElse(throw new IllegalArgumentException("Can't read defaults from Enrich config"))))
       igluClient <- Resource.eval(IgluCirceClient.fromResolver[IO](Resolver[IO](List(Registry.IgluCentral), None), 500, enrichConfig.maxJsonDepth))
       jsEnrichment <- Resource.eval(buildJSEnrichment())
       enrichmentRegistry = new EnrichmentRegistry[IO](javascriptScript = List(jsEnrichment))
+      registryColdswap <- Coldswap.make(Resource.pure[IO, EnrichmentRegistry[IO]](enrichmentRegistry))
       processor = Processor(BuildInfo.name, BuildInfo.version)
       lookup = JavaNetRegistryLookup.ioLookupInstance[IO]
       httpClient <- EmberClientBuilder.default[IO].build
       storage = new InMemoryStorage()
-    } yield new EventSink(igluClient, lookup, enrichmentRegistry, OutputFormat.None, None, processor, enrichConfig, httpClient, storage)
+    } yield new EventSink(igluClient, lookup, registryColdswap, OutputFormat.None, None, processor, enrichConfig, httpClient, storage)
   }
 
   private def buildJSEnrichment(): IO[JavascriptScriptEnrichment] = {

--- a/src/test/scala/com.snowplowanalytics.snowplow.micro/EventSinkSpec.scala
+++ b/src/test/scala/com.snowplowanalytics.snowplow.micro/EventSinkSpec.scala
@@ -75,7 +75,7 @@ class EventSinkSpec extends CatsResource[IO, EventSink] with SpecificationLike {
       val raw = buildRawEvent()
       val withoutEvent = raw.copy(parameters = raw.parameters - "e")
       val expected = "Error while validating the event"
-      sink.validateEvent(withoutEvent).value.map {
+      sink.validateEvent(withoutEvent).map {
         _ must beLike {
           case OptionIor.Both((errors, _), _) if errors.exists(_.contains(expected)) => ok
         }
@@ -85,7 +85,7 @@ class EventSinkSpec extends CatsResource[IO, EventSink] with SpecificationLike {
     "should fail for an invalid unstructured event" >> withResource { sink =>
       val raw = buildRawEvent(Some(buildUnstruct(sdjInvalid)))
       val expected = "Error while validating the event"
-      sink.validateEvent(raw).value.map {
+      sink.validateEvent(raw).map {
         _ must beLike {
           case OptionIor.Both((errors, _), _) if errors.exists(_.contains(expected)) => ok
         }
@@ -95,7 +95,7 @@ class EventSinkSpec extends CatsResource[IO, EventSink] with SpecificationLike {
     "should fail if the event has an invalid context" >> withResource { sink =>
       val raw = buildRawEvent(None, Some(buildContexts(List(sdjInvalid))))
       val expected = "Error while validating the event"
-      sink.validateEvent(raw).value.map {
+      sink.validateEvent(raw).map {
         _ must beLike {
           case OptionIor.Both((errors, _), _) if errors.exists(_.contains(expected)) => ok
         }
@@ -105,7 +105,7 @@ class EventSinkSpec extends CatsResource[IO, EventSink] with SpecificationLike {
     "should fail for a unstructured event with an unknown schema" >> withResource { sink =>
       val raw = buildRawEvent(Some(buildUnstruct(sdjDoesNotExist)))
       val expected = "Error while validating the event"
-      sink.validateEvent(raw).value.map {
+      sink.validateEvent(raw).map {
         _ must beLike {
           case OptionIor.Both((errors, _), _) if errors.exists(_.contains(expected)) => ok
         }
@@ -115,7 +115,7 @@ class EventSinkSpec extends CatsResource[IO, EventSink] with SpecificationLike {
     "should fail if the event has a context with an unknown schema" >> withResource { sink =>
       val raw = buildRawEvent(None, Some(buildContexts(List(sdjDoesNotExist))))
       val expected = "Error while validating the event"
-      sink.validateEvent(raw).value.map {
+      sink.validateEvent(raw).map {
         _ must beLike {
           case OptionIor.Both((errors, _), _) if errors.exists(_.contains(expected)) => ok
         }
@@ -125,7 +125,7 @@ class EventSinkSpec extends CatsResource[IO, EventSink] with SpecificationLike {
     "extract the type of an event" >> withResource { sink =>
       val raw = buildRawEvent()
       val expected = "page_ping"
-      sink.validateEvent(raw).value.map {
+      sink.validateEvent(raw).map {
         _ must beLike {
           case OptionIor.Right(GoodEvent(_, typE, _, _, _, _)) if typE === Some(expected) => ok
         }
@@ -135,7 +135,7 @@ class EventSinkSpec extends CatsResource[IO, EventSink] with SpecificationLike {
     "should extract the schema of an unstructured event" >> withResource { sink =>
       val raw = buildRawEvent(Some(buildUnstruct(sdjLinkClick)))
       val expected = schemaLinkClick
-      sink.validateEvent(raw).value.map {
+      sink.validateEvent(raw).map {
         _ must beLike {
           case OptionIor.Right(GoodEvent(_, _, schema, _, _, _)) if schema === Some(expected) => ok
         }
@@ -145,7 +145,7 @@ class EventSinkSpec extends CatsResource[IO, EventSink] with SpecificationLike {
     "should extract the contexts of an event" >> withResource { sink =>
       val raw = buildRawEvent(None, Some(buildContexts(List(sdjLinkClick, sdjMobileContext))))
       val expected = List(schemaLinkClick, schemaMobileContext)
-      sink.validateEvent(raw).value.map {
+      sink.validateEvent(raw).map {
         _ must beLike {
           case OptionIor.Right(GoodEvent(_, _, _, contexts, _, _)) if contexts === expected => ok
         }
@@ -154,7 +154,7 @@ class EventSinkSpec extends CatsResource[IO, EventSink] with SpecificationLike {
 
     "should return nothing if the event is dropped by JS enrichment" >> withResource { sink =>
       val raw = buildRawEvent(appId = "drop-all")
-      sink.validateEvent(raw).value.map {
+      sink.validateEvent(raw).map {
         _ must beLike {
           case OptionIor.None => ok
         }
@@ -179,7 +179,7 @@ class EventSinkSpec extends CatsResource[IO, EventSink] with SpecificationLike {
   private def buildJSEnrichment(): IO[JavascriptScriptEnrichment] = {
     val js = Source.fromResource("js-enrichment.js").getLines().mkString("\n")
     val key = SchemaKey("com.snowplowanalytics.snowplow", "javascript_script_config", "jsonschema", SchemaVer.Full(1, 0, 0))
-    JavascriptScriptEnrichment.create(key, js, JsonObject(), false) match {
+    JavascriptScriptEnrichment.create(key, js, JsonObject(), false, Set("*")) match {
       case Right(enrichment) => IO.pure(enrichment)
       case Left(error) => IO.raiseError(new RuntimeException(error))
     }


### PR DESCRIPTION
Use Coldswap from runtime-common to manage the EnrichmentRegistry lifecycle. Assets (MaxMind DBs, referer-parser, etc.) are periodically re-downloaded, and if changes are detected via ETags, the registry is rebuilt under an exclusive lock without dropping events.

- Add AssetRefresher with initial download and periodic refresh stream
- Add conditional download support (ETag/If-None-Match) to BlobUtils
- Add --config CLI alias and enrich {} config section for assetsUpdatePeriod
- Switch EventSink to use Coldswap instead of a fixed EnrichmentRegistry