### PR TITLE
Add shareable view URLs with "Copy view URL" button

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -29,11 +29,16 @@ import {
   FilterX,
   MoreVertical,
   TimerReset,
+  Link,
+  Check,
 } from 'lucide-react'
 import { type ColumnFiltersState, type SortingState } from '@tanstack/react-table'
+import { parseViewUrl, serializeViewUrl } from '@/utils/view-url'
 
 function App() {
   const { isAuthenticated, isLoading: authIsLoading, error, getAccessToken } = useAuth()
+  const [urlState] = useState(() => parseViewUrl())
+  const isUrlMode = urlState !== null
   const [eventData, setEventData] = useState<EventsResponse>({
     events: [],
     totalPages: 0,
@@ -52,8 +57,12 @@ function App() {
     value: any
     title: string
   } | null>(null)
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
-  const [selectedTimeBucket, setSelectedTimeBucket] = useState<string | null>(null)
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(
+    urlState?.filters ?? []
+  )
+  const [selectedTimeBucket, setSelectedTimeBucket] = useState<string | null>(
+    urlState?.timeBucket ?? null
+  )
   const [lastRefreshTime, setLastRefreshTime] = useState<Date | null>(null)
   const [showActionsMenu, setShowActionsMenu] = useState(false)
   const [columnStats, setColumnStats] = useState<Record<string, ColumnStats>>(
@@ -103,6 +112,8 @@ function App() {
       scrollToLastColumn()
       updateColumnStats(columnNames)
     },
+    initialColumns: urlState?.columns,
+    persistToStorage: !isUrlMode,
   })
 
   // Set initial sorting when collector_tstamp is available
@@ -359,6 +370,24 @@ function App() {
     }
   }, [autoRefresh])
 
+  // Sync state to URL in URL mode
+  const selectedColumnNames = selectedColumns.map((col) => col.name)
+  useEffect(() => {
+    if (!isUrlMode) return
+    const url = serializeViewUrl(selectedColumns, columnFilters, selectedTimeBucket)
+    const { pathname, search } = new URL(url)
+    window.history.replaceState({}, '', pathname + search)
+  }, [isUrlMode, selectedColumnNames.join(','), columnFilters, selectedTimeBucket])
+
+  // "Copied!" feedback state
+  const [copied, setCopied] = useState(false)
+  const copyViewUrl = () => {
+    const url = serializeViewUrl(selectedColumns, columnFilters, selectedTimeBucket)
+    navigator.clipboard.writeText(url)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
   // Initial load - only when authentication is ready
   useEffect(() => {
     if (isAuthenticated && !authIsLoading) {
@@ -478,6 +507,25 @@ function App() {
               <Columns3Cog className="mr-2 h-4 w-4" />
               Pick columns
             </Button>
+            <TooltipProvider>
+              <Tooltip delayDuration={0}>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={copyViewUrl}
+                  >
+                    {copied
+                      ? <><Check className="mr-2 h-4 w-4" />Copied!</>
+                      : <><Link className="mr-2 h-4 w-4" />Copy view URL</>
+                    }
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  Copies selected columns and applied filters
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
             <div className="relative">
               <Button
                 variant="outline"

--- a/ui/src/hooks/useColumnManager.ts
+++ b/ui/src/hooks/useColumnManager.ts
@@ -45,6 +45,8 @@ type UseColumnManagerProps = {
   availableColumnNames: string[]
   setColumnFilters: OnChangeFn<ColumnFiltersState>
   onColumnAdded?: (columnNames: string[]) => void
+  initialColumns?: string[]
+  persistToStorage?: boolean
 }
 
 type UseColumnManagerReturn = {
@@ -59,14 +61,12 @@ export function useColumnManager({
   availableColumnNames,
   setColumnFilters,
   onColumnAdded,
+  initialColumns,
+  persistToStorage = true,
 }: UseColumnManagerProps): UseColumnManagerReturn {
   const [selectedColumnNames, setSelectedColumnNames] = useState<string[]>(
-    loadSelectedColumns()
+    initialColumns ?? loadSelectedColumns()
   )
-
-  useEffect(() => {
-    saveSelectedColumns(selectedColumnNames)
-  }, [selectedColumnNames])
 
   const selectedColumns = useMemo(() => {
     return selectedColumnNames.map(createColumnMetadata)
@@ -99,10 +99,11 @@ export function useColumnManager({
       const updated = selectedColumnNames.filter((c) => c != fieldName)
       setColumnFilters((filters) => filters.filter((f) => f.id !== fieldName))
       setSelectedColumnNames(updated)
+      if (persistToStorage) saveSelectedColumns(updated)
     } else {
       const updated = [...selectedColumnNames, fieldName]
       setSelectedColumnNames(updated)
-      // Notify that a column was added
+      if (persistToStorage) saveSelectedColumns(updated)
       onColumnAdded?.(updated)
     }
   }
@@ -112,12 +113,14 @@ export function useColumnManager({
     const column = reordered.splice(fromIndex, 1)[0]
     reordered.splice(toIndex, 0, column)
     setSelectedColumnNames(reordered)
+    if (persistToStorage) saveSelectedColumns(reordered)
   }
 
   const resetToDefaults = () => {
     const removedColumns = selectedColumnNames.filter(col => !DEFAULT_COLUMNS.includes(col))
     setColumnFilters((filters) => filters.filter((f) => !removedColumns.includes(f.id)))
     setSelectedColumnNames([...DEFAULT_COLUMNS])
+    if (persistToStorage) saveSelectedColumns([...DEFAULT_COLUMNS])
   }
 
   return {

--- a/ui/src/utils/view-url.ts
+++ b/ui/src/utils/view-url.ts
@@ -1,0 +1,74 @@
+import type { ColumnFiltersState } from '@tanstack/react-table'
+import type { ColumnMetadata } from '@/utils/column-metadata'
+
+export type UrlViewState = {
+  columns: string[]
+  filters: ColumnFiltersState
+  timeBucket: string | null
+}
+
+export function parseViewUrl(): UrlViewState | null {
+  const params = new URLSearchParams(window.location.search)
+
+  const columns: string[] = []
+  const filters: ColumnFiltersState = []
+  let timeBucket: string | null = null
+
+  for (const [key, value] of params) {
+    if (key === 'status') {
+      if (value) {
+        filters.push({ id: 'status', value })
+      }
+    } else if (key === 'time') {
+      const parts = value.split('~')
+      if (parts.length === 2) {
+        timeBucket = `${parts[0]}|${parts[1]}`
+      }
+    } else {
+      columns.push(key)
+      if (value) {
+        filters.push({ id: key, value: value.split('~') })
+      }
+    }
+  }
+
+  if (columns.length === 0) return null
+  return { columns, filters, timeBucket }
+}
+
+export function serializeViewUrl(
+  selectedColumns: ColumnMetadata[],
+  columnFilters: ColumnFiltersState,
+  selectedTimeBucket: string | null,
+): string {
+  const parts: string[] = []
+
+  for (const col of selectedColumns) {
+    const filter = columnFilters.find((f) => f.id === col.name)
+    const encodedName = encodeURIComponent(col.name)
+    if (filter && filter.value) {
+      const values = Array.isArray(filter.value)
+        ? (filter.value as string[])
+        : [String(filter.value)]
+      if (values.length > 0) {
+        parts.push(`${encodedName}=${values.map((v) => encodeURIComponent(v)).join('~')}`)
+      } else {
+        parts.push(`${encodedName}=`)
+      }
+    } else {
+      parts.push(`${encodedName}=`)
+    }
+  }
+
+  const statusFilter = columnFilters.find((f) => f.id === 'status')
+  if (statusFilter?.value) {
+    parts.push(`status=${encodeURIComponent(String(statusFilter.value))}`)
+  }
+
+  if (selectedTimeBucket) {
+    const [start, end] = selectedTimeBucket.split('|')
+    parts.push(`time=${encodeURIComponent(start)}~${encodeURIComponent(end)}`)
+  }
+
+  return `${window.location.origin}${window.location.pathname}?${parts.join('&')}`
+}


### PR DESCRIPTION
Encodes selected columns, filters, and time selection into a URL that can be shared. Opening a shared URL loads the view without touching localStorage. In URL mode, user modifications update the URL via replaceState; in personal mode, columns persist to localStorage as before.