### PR TITLE
Time filter

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,10 +35,10 @@ jobs:
         java-version: 21
         distribution: adopt
 
-    - name: Set up Node 20
+    - name: Set up Node 24
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 24
 
     - name: Install sbt
       uses: sbt/setup-sbt@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,10 +35,10 @@ jobs:
         java-version: 21
         distribution: adopt
 
-    - name: Set up Node 18
-      uses: actions/setup-node@v3
+    - name: Set up Node 20
+      uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 20
 
     - name: Install sbt
       uses: sbt/setup-sbt@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Node 20
+    - name: Set up Node 24
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 24
         cache: npm
         cache-dependency-path: ui/package-lock.json
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,36 @@ name: Test
 on: [push, pull_request]
 
 jobs:
+  ui:
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ui
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Node 20
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: npm
+        cache-dependency-path: ui/package-lock.json
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run tests
+      run: npm test
+
+    - name: Lint
+      run: npm run lint
+
+    - name: Build
+      run: npm run build
+
   test:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,6 @@ jobs:
     - name: Run tests
       run: npm test
 
-    - name: Lint
-      run: npm run lint
-
     - name: Build
       run: npm run build
 

--- a/src/main/scala/com.snowplowanalytics.snowplow.micro/storage/PostgresqlStorage.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.micro/storage/PostgresqlStorage.scala
@@ -48,15 +48,16 @@ private[micro] class PostgresqlStorage(xa: Transactor[IO]) extends EventStorage 
         val domainUserid = goodEvent.event.domain_userid
         val vTracker = goodEvent.event.v_tracker
         val userId = goodEvent.event.user_id
-        (goodEvent.event.event_id.toString, goodEvent.event.collector_tstamp, eventJson, goodEvent.incomplete, appId, eventName, platform, nameTracker, domainUserid, vTracker, userId)
+        val networkUserid = goodEvent.event.network_userid
+        (goodEvent.event.event_id.toString, goodEvent.event.collector_tstamp, eventJson, goodEvent.incomplete, appId, eventName, platform, nameTracker, domainUserid, vTracker, userId, networkUserid)
       }
 
       val allColumns = eventJsons.map(EventStorage.extractColumnsFromEvent)
         .reduce(_.union(_)).toList
 
       val insertEventsProgram = {
-        val sql = "INSERT INTO events (event_id, timestamp, event_json, failed, app_id, event_name, platform, name_tracker, domain_userid, v_tracker, user_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT (event_id) DO NOTHING"
-        Update[(String, Instant, Json, Boolean, Option[String], Option[String], Option[String], Option[String], Option[String], Option[String], Option[String])](sql).updateMany(eventData)
+        val sql = "INSERT INTO events (event_id, timestamp, event_json, failed, app_id, event_name, platform, name_tracker, domain_userid, v_tracker, user_id, network_userid) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT (event_id) DO NOTHING"
+        Update[(String, Instant, Json, Boolean, Option[String], Option[String], Option[String], Option[String], Option[String], Option[String], Option[String], Option[String])](sql).updateMany(eventData)
       }
 
       val insertColumnsProgram = if (allColumns.nonEmpty) {
@@ -251,7 +252,7 @@ private[micro] object PostgresqlStorage {
   implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
   // Columns that have dedicated table columns (rather than JSON extraction)
-  private val INDEXED_COLUMNS = Set("event_id", "app_id", "event_name", "platform", "name_tracker", "domain_userid", "v_tracker", "user_id")
+  private val INDEXED_COLUMNS = Set("event_id", "app_id", "event_name", "platform", "name_tracker", "domain_userid", "v_tracker", "user_id", "network_userid")
 
   // Limit scan depth for columnStats queries to improve performance
   // Only scan most recent N events instead of entire table
@@ -307,7 +308,8 @@ private[micro] object PostgresqlStorage {
         name_tracker TEXT,
         domain_userid TEXT,
         v_tracker TEXT,
-        user_id TEXT
+        user_id TEXT,
+        network_userid TEXT
       )
     """.update.run.void *>
       // Timestamp-only index for queries without column filters
@@ -323,7 +325,10 @@ private[micro] object PostgresqlStorage {
       sql"CREATE INDEX IF NOT EXISTS idx_events_v_tracker_timestamp ON events(v_tracker, timestamp)".update.run.void *>
       // Migration: add user_id column if table already exists without it
       sql"ALTER TABLE events ADD COLUMN IF NOT EXISTS user_id TEXT".update.run.void *>
-      sql"CREATE INDEX IF NOT EXISTS idx_events_user_id_timestamp ON events(user_id, timestamp)".update.run.void
+      sql"CREATE INDEX IF NOT EXISTS idx_events_user_id_timestamp ON events(user_id, timestamp)".update.run.void *>
+      // Migration: add network_userid column if table already exists without it
+      sql"ALTER TABLE events ADD COLUMN IF NOT EXISTS network_userid TEXT".update.run.void *>
+      sql"CREATE INDEX IF NOT EXISTS idx_events_network_userid_timestamp ON events(network_userid, timestamp)".update.run.void
   }
 
   private def createColumnsTable: ConnectionIO[Unit] = {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -31,6 +31,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
+        "@testing-library/jest-dom": "^7.0.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^24.5.2",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
@@ -41,6 +43,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.4.0",
+        "jsdom": "^30.0.1",
         "postcss": "^8.5.6",
         "prettier": "^3.6.2",
         "tailwindcss": "^4.1.13",
@@ -50,6 +53,13 @@
         "vite-plugin-checker": "^0.11.0",
         "vitest": "^4.1.10"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -61,6 +71,59 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@auth0/auth0-spa-js": {
@@ -423,6 +486,159 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1019,6 +1235,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -3333,6 +3567,99 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
+      "integrity": "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3948,6 +4275,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3981,6 +4319,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/assertion-error": {
@@ -4046,6 +4394,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -4269,6 +4627,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -4396,6 +4775,35 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4414,6 +4822,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -4426,6 +4841,16 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.0",
@@ -4452,6 +4877,14 @@
         "@react-dnd/invariant": "^4.0.1",
         "redux": "^4.2.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4490,6 +4923,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-cookie": {
@@ -5029,6 +5475,19 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5064,6 +5523,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/internmap": {
@@ -5108,6 +5577,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5141,6 +5617,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -5502,6 +6029,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5510,6 +6048,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -5533,6 +6078,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -5734,6 +6289,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5840,6 +6408,44 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6188,6 +6794,20 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
@@ -6195,6 +6815,16 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/reselect": {
@@ -6290,6 +6920,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -6359,6 +7002,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -6384,6 +7040,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.3.1",
@@ -6529,6 +7192,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6540,6 +7223,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -6610,6 +7319,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -7041,6 +7760,54 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7083,6 +7850,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -47,7 +47,8 @@
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.44.0",
         "vite": "^7.1.7",
-        "vite-plugin-checker": "^0.11.0"
+        "vite-plugin-checker": "^0.11.0",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -3031,6 +3032,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.13.tgz",
@@ -3370,6 +3378,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -3431,6 +3450,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -3769,6 +3795,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3842,6 +3981,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/autoprefixer": {
@@ -3997,6 +4146,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4339,6 +4498,13 @@
       "integrity": "sha512-UTlYYhXGLOy05P/vKVT2Ui7WtC7NiRzGtJyAKKn32g5Gvcjn7KAClLPWlipCtxIus934dFg9o9jXiBL0nP+t9Q==",
       "license": "MIT"
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.10",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
@@ -4588,6 +4754,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4603,6 +4779,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5317,9 +5503,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.19",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
-      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -5471,6 +5657,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5553,6 +5753,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6122,6 +6329,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6130,6 +6344,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -6226,6 +6454,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6272,6 +6517,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -6676,6 +6931,109 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -6697,6 +7055,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "test": "vitest run",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -51,6 +52,7 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.44.0",
     "vite": "^7.1.7",
-    "vite-plugin-checker": "^0.11.0"
+    "vite-plugin-checker": "^0.11.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -36,6 +36,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
+    "@testing-library/jest-dom": "^7.0.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^24.5.2",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
@@ -46,6 +48,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.4.0",
+    "jsdom": "^30.0.1",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
     "tailwindcss": "^4.1.13",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { DataTable } from '@/components/DataTable'
 import { ColumnSelector } from '@/components/ColumnSelector'
@@ -13,6 +13,13 @@ import {
   type EventsFilter,
   EventsApiService,
 } from '@/services/api'
+import {
+  describeTimeFilter,
+  formatDayHour,
+  formatMinute,
+  resolveTimeFilter,
+  type TimeFilter,
+} from '@/utils/time-filter'
 import { useColumnManager } from '@/hooks/useColumnManager'
 import { Button } from '@/components/ui/button'
 import { Toggle } from '@/components/ui/toggle'
@@ -34,6 +41,7 @@ import {
 } from 'lucide-react'
 import { type ColumnFiltersState, type SortingState } from '@tanstack/react-table'
 import { parseViewUrl, serializeViewUrl } from '@/utils/view-url'
+import { TIMESTAMP_COLUMN } from '@/utils/fixed-columns'
 
 function App() {
   const { isAuthenticated, isLoading: authIsLoading, error } = useAuth()
@@ -102,15 +110,19 @@ function Dashboard() {
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(
     urlState?.filters ?? []
   )
-  const [selectedTimeBucket, setSelectedTimeBucket] = useState<string | null>(
-    urlState?.timeBucket ?? null
+  const [timeFilter, setTimeFilter] = useState<TimeFilter | null>(
+    urlState?.timeFilter ?? null
   )
   const [lastRefreshTime, setLastRefreshTime] = useState<Date | null>(null)
+  // Relative filters need an instant to resolve against before the first refresh lands
+  const timeFilterAnchor = useMemo(() => lastRefreshTime ?? new Date(), [lastRefreshTime])
   const [showActionsMenu, setShowActionsMenu] = useState(false)
   const [columnStats, setColumnStats] = useState<Record<string, ColumnStats>>(
     {}
   )
-  const [sorting, setSorting] = useState<SortingState>([])
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: TIMESTAMP_COLUMN, desc: true },
+  ])
   const [autoRefresh, setAutoRefresh] = useState(false)
   const autoRefreshIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const refreshAllDataRef = useRef<() => void>(() => {})
@@ -157,14 +169,14 @@ function Dashboard() {
     persistToStorage: !isUrlMode,
   })
 
-  // Set initial sorting when collector_tstamp is available
   useEffect(() => {
-    if (sorting.length === 0 && selectedColumns.some(col => col.name === 'collector_tstamp')) {
-      setSorting([{ id: 'collector_tstamp', desc: true }])
+    if (sorting.length === 0) {
+      setSorting([{ id: TIMESTAMP_COLUMN, desc: true }])
     }
-  }, [selectedColumns, sorting])
+  }, [sorting])
 
-  const buildEventsRequest = (isRefresh = false): EventsRequest => {
+  // Passing a refresh time both marks this as a refresh and anchors relative filters to it
+  const buildEventsRequest = (refreshTime?: Date): EventsRequest => {
     // Separate status filter from column filters
     const statusFilter = columnFilters.find(f => f.id === 'status')
     const regularFilters = columnFilters.filter(f => f.id !== 'status')
@@ -183,28 +195,19 @@ function Dashboard() {
         : undefined
       : undefined
 
-    let timeRange
-    if (isRefresh) {
-      // only filter by selected bucket, or not at all
-      timeRange = selectedTimeBucket
-        ? {
-            start: selectedTimeBucket.split('|')[0],
-            end: selectedTimeBucket.split('|')[1],
-          }
-        : undefined
-    } else {
+    // relative filters ("last 15 min") re-anchor on every refresh, then stay put
+    // between refreshes so paging through results stays stable
+    const anchor = refreshTime ?? timeFilterAnchor
+    const range = timeFilter ? resolveTimeFilter(timeFilter, anchor) : undefined
+
+    let timeRange = range
+    if (!refreshTime && lastRefreshTime) {
       // add a (non-inclusive) upper bound to avoid getting newer events in the results
-      if (selectedTimeBucket && lastRefreshTime) {
-        const bucketStart = selectedTimeBucket.split('|')[0]
-        const bucketEnd = selectedTimeBucket.split('|')[1]
-        const bucketEndTime = new Date(bucketEnd)
-        timeRange = {
-          start: bucketStart,
-          end: bucketEndTime < lastRefreshTime ? bucketEnd : lastRefreshTime.toISOString(),
-        }
-      } else if (lastRefreshTime) {
-        timeRange = { end: lastRefreshTime.toISOString() }
-      }
+      const end =
+        range?.end && new Date(range.end) < lastRefreshTime
+          ? range.end
+          : lastRefreshTime.toISOString()
+      timeRange = { start: range?.start, end }
     }
 
     return {
@@ -221,7 +224,7 @@ function Dashboard() {
     setIsLoading(true)
     try {
       const token = await getAccessToken()
-      const request = buildEventsRequest(false)
+      const request = buildEventsRequest()
       const fetchedEventData =
         await EventsApiService.fetchFilteredEvents(request, token)
       setEventData(fetchedEventData)
@@ -244,9 +247,10 @@ function Dashboard() {
     setIsRefreshing(true)
     try {
       setCurrentPage(1)
+      const refreshTime = new Date()
       const token = await getAccessToken()
       const selectedColumnNames = selectedColumns.map((col) => col.name)
-      const request = { ...buildEventsRequest(true), page: 1 }
+      const request = { ...buildEventsRequest(refreshTime), page: 1 }
 
       const [
         fetchedEventData,
@@ -267,7 +271,7 @@ function Dashboard() {
       setDaysTimelineData(days)
       setAvailableColumnNames(fetchedColumns)
       setColumnStats(fetchedColumnStats)
-      setLastRefreshTime(new Date())
+      setLastRefreshTime(refreshTime)
     } catch (err) {
       console.error('Failed to refresh data:', err)
     } finally {
@@ -289,7 +293,7 @@ function Dashboard() {
       setMinutesTimelineData({ points: [] })
       setDaysTimelineData({ points: [] })
       setAvailableColumnNames([])
-      setSelectedTimeBucket(null)
+      setTimeFilter(null)
       setCurrentPage(1)
       setLastRefreshTime(null)
     } catch (err) {
@@ -343,11 +347,11 @@ function Dashboard() {
   }
 
   // Check if any filters are active
-  const hasActiveFilters = selectedTimeBucket !== null || columnFilters.length > 0
+  const hasActiveFilters = timeFilter !== null || columnFilters.length > 0
 
   // Reset all filters
   const resetAllFilters = () => {
-    setSelectedTimeBucket(null)
+    setTimeFilter(null)
     setColumnFilters([])
   }
 
@@ -355,12 +359,8 @@ function Dashboard() {
   const getActiveFilters = () => {
     const filters: string[] = []
 
-    if (selectedTimeBucket) {
-      const bucketStart = selectedTimeBucket.split('|')[0]
-      const bucketEnd = selectedTimeBucket.split('|')[1]
-      const startDate = new Date(bucketStart)
-      const endDate = new Date(bucketEnd)
-      filters.push(`Time: ${startDate.toLocaleString()} – ${endDate.toLocaleString()}`)
+    if (timeFilter) {
+      filters.push(`Time: ${describeTimeFilter(timeFilter)}`)
     }
 
     if (columnFilters.length > 0) {
@@ -385,7 +385,7 @@ function Dashboard() {
     }, 400)
 
     return () => clearTimeout(timeoutId)
-  }, [columnFilters, selectedTimeBucket, currentPage, sorting])
+  }, [columnFilters, timeFilter, currentPage, sorting])
 
   // Keep refreshAllDataRef up to date so the interval always calls the latest version
   useEffect(() => {
@@ -415,10 +415,10 @@ function Dashboard() {
   const selectedColumnNames = selectedColumns.map((col) => col.name)
   useEffect(() => {
     if (!isUrlMode) return
-    const url = serializeViewUrl(selectedColumns, columnFilters, selectedTimeBucket)
+    const url = serializeViewUrl(selectedColumns, columnFilters, timeFilter)
     const { pathname, search } = new URL(url)
     window.history.replaceState({}, '', pathname + search)
-  }, [isUrlMode, selectedColumnNames.join(','), columnFilters, selectedTimeBucket])
+  }, [isUrlMode, selectedColumnNames.join(','), columnFilters, timeFilter])
 
   // Re-fetch column stats whenever selected columns change (after initial load)
   useEffect(() => {
@@ -429,7 +429,7 @@ function Dashboard() {
   // "Copied!" feedback state
   const [copied, setCopied] = useState(false)
   const copyViewUrl = () => {
-    const url = serializeViewUrl(selectedColumns, columnFilters, selectedTimeBucket)
+    const url = serializeViewUrl(selectedColumns, columnFilters, timeFilter)
     navigator.clipboard.writeText(url)
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
@@ -581,25 +581,19 @@ function Dashboard() {
             <div className="flex-1">
               <EventsChart
                 timelineData={daysTimelineData}
-                selectedBucket={selectedTimeBucket}
-                onBucketClick={setSelectedTimeBucket}
-                timeFormat={(date) => date.toLocaleDateString('en-US', {
-                  month: 'short',
-                  day: 'numeric',
-                  hour: '2-digit'
-                })}
+                timeFilter={timeFilter}
+                onTimeFilterChange={setTimeFilter}
+                timeFilterAnchor={timeFilterAnchor}
+                timeFormat={formatDayHour}
               />
             </div>
             <div className="flex-1">
               <EventsChart
                 timelineData={minutesTimelineData}
-                selectedBucket={selectedTimeBucket}
-                onBucketClick={setSelectedTimeBucket}
-                timeFormat={(date) => date.toLocaleTimeString('en-US', {
-                  hour12: false,
-                  hour: '2-digit',
-                  minute: '2-digit',
-                })}
+                timeFilter={timeFilter}
+                onTimeFilterChange={setTimeFilter}
+                timeFilterAnchor={timeFilterAnchor}
+                timeFormat={formatMinute}
               />
             </div>
           </div>
@@ -612,7 +606,9 @@ function Dashboard() {
               selectedCellId={selectedCellId}
               columnFilters={columnFilters}
               setColumnFilters={setColumnFilters}
-              selectedTimeBucket={selectedTimeBucket}
+              timeFilter={timeFilter}
+              onTimeFilterChange={setTimeFilter}
+              timeFilterAnchor={timeFilterAnchor}
               onJsonCellToggle={toggleJsonPanel}
               onReorderColumns={reorderColumns}
               onRowClick={handleRowClick}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -169,12 +169,6 @@ function Dashboard() {
     persistToStorage: !isUrlMode,
   })
 
-  useEffect(() => {
-    if (sorting.length === 0) {
-      setSorting([{ id: TIMESTAMP_COLUMN, desc: true }])
-    }
-  }, [sorting])
-
   // Passing a refresh time both marks this as a refresh and anchors relative filters to it
   const buildEventsRequest = (refreshTime?: Date): EventsRequest => {
     // Separate status filter from column filters

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
 import { DataTable } from '@/components/DataTable'
 import { ColumnSelector } from '@/components/ColumnSelector'
@@ -114,8 +114,8 @@ function Dashboard() {
     urlState?.timeFilter ?? null
   )
   const [lastRefreshTime, setLastRefreshTime] = useState<Date | null>(null)
-  // Relative filters need an instant to resolve against before the first refresh lands
-  const timeFilterAnchor = useMemo(() => lastRefreshTime ?? new Date(), [lastRefreshTime])
+  const [mountTime] = useState(() => new Date())
+  const timeFilterAnchor = lastRefreshTime ?? mountTime
   const [showActionsMenu, setShowActionsMenu] = useState(false)
   const [columnStats, setColumnStats] = useState<Record<string, ColumnStats>>(
     {}
@@ -169,9 +169,7 @@ function Dashboard() {
     persistToStorage: !isUrlMode,
   })
 
-  // Passing a refresh time both marks this as a refresh and anchors relative filters to it
   const buildEventsRequest = (refreshTime?: Date): EventsRequest => {
-    // Separate status filter from column filters
     const statusFilter = columnFilters.find(f => f.id === 'status')
     const regularFilters = columnFilters.filter(f => f.id !== 'status')
 
@@ -180,7 +178,6 @@ function Dashboard() {
       values: Array.isArray(filter.value) ? filter.value as string[] : [String(filter.value)],
     }))
 
-    // Map status filter to validEvents field
     const validEvents = statusFilter
       ? statusFilter.value === 'valid'
         ? true
@@ -194,15 +191,15 @@ function Dashboard() {
     const anchor = refreshTime ?? timeFilterAnchor
     const range = timeFilter ? resolveTimeFilter(timeFilter, anchor) : undefined
 
-    let timeRange = range
-    if (!refreshTime && lastRefreshTime) {
-      // add a (non-inclusive) upper bound to avoid getting newer events in the results
-      const end =
-        range?.end && new Date(range.end) < lastRefreshTime
-          ? range.end
-          : lastRefreshTime.toISOString()
-      timeRange = { start: range?.start, end }
-    }
+    // Between refreshes, cap the range at the last refresh (exclusively) so that paging
+    // through the results doesn't pick up events that have arrived since
+    const cap = refreshTime ? null : lastRefreshTime
+    const timeRange = cap
+      ? {
+          start: range?.start,
+          end: range?.end && new Date(range.end) < cap ? range.end : cap.toISOString(),
+        }
+      : range
 
     return {
       filters,

--- a/ui/src/components/DataTable.tsx
+++ b/ui/src/components/DataTable.tsx
@@ -30,9 +30,11 @@ import {
   type EventColumnMeta,
 } from '@/utils/column-generation'
 import type { Event, ColumnStats } from '@/services/api'
+import type { TimeFilter } from '@/utils/time-filter'
 import { type ColumnMetadata } from '@/utils/column-metadata'
 import { MultiSelectFilter } from '@/components/MultiSelectFilter'
 import { StatusDropdown } from '@/components/StatusDropdown'
+import { TimeRangeFilter } from '@/components/TimeRangeFilter'
 
 type DataTableProps = {
   events: Event[]
@@ -41,7 +43,9 @@ type DataTableProps = {
   selectedCellId: string | null
   columnFilters: ColumnFiltersState
   setColumnFilters: OnChangeFn<ColumnFiltersState>
-  selectedTimeBucket: string | null
+  timeFilter: TimeFilter | null
+  onTimeFilterChange: (value: TimeFilter | null) => void
+  timeFilterAnchor: Date
   onJsonCellToggle: (cellId: string, value: any, title: string) => void
   onReorderColumns: (fromIndex: number, toIndex: number) => void
   onRowClick: (rowId: string, event: Event) => void
@@ -62,7 +66,9 @@ export function DataTable({
   selectedCellId,
   columnFilters,
   setColumnFilters,
-  selectedTimeBucket,
+  timeFilter,
+  onTimeFilterChange,
+  timeFilterAnchor,
   onJsonCellToggle,
   onReorderColumns,
   onRowClick,
@@ -156,6 +162,13 @@ export function DataTable({
                                 )
                               }}
                             />
+                          ) : (header.column.columnDef.meta as EventColumnMeta)
+                              ?.eventTimeFilter ? (
+                            <TimeRangeFilter
+                              value={timeFilter}
+                              onChange={onTimeFilterChange}
+                              anchor={timeFilterAnchor}
+                            />
                           ) : header.column.getCanFilter() ? (
                             <MultiSelectFilter
                               options={
@@ -218,12 +231,14 @@ export function DataTable({
                     >
                       {(() => {
                         const hasColumnFilters = columnFilters.length > 0
-                        const hasSelectedTimeBucket = selectedTimeBucket !== null
+                        const hasTimeFilter = timeFilter !== null
 
-                        if (hasColumnFilters && hasSelectedTimeBucket) {
-                          return 'No events matching filters and selected time'
+                        if (hasColumnFilters && hasTimeFilter) {
+                          return 'No events matching filters in the selected time range'
                         } else if (hasColumnFilters) {
                           return 'No events matching filters'
+                        } else if (hasTimeFilter) {
+                          return 'No events in the selected time range'
                         } else {
                           return 'No events'
                         }

--- a/ui/src/components/EventsChart.tsx
+++ b/ui/src/components/EventsChart.tsx
@@ -6,13 +6,19 @@ import {
   ChartTooltip,
 } from '@/components/ui/chart'
 import { type TimelineData } from '@/services/api'
+import { overlapsRange, resolveTimeFilter, type TimeFilter } from '@/utils/time-filter'
 
 interface EventsChartProps {
   timelineData: TimelineData
-  selectedBucket: string | null
-  onBucketClick: (bucketKey: string | null) => void
+  timeFilter: TimeFilter | null
+  onTimeFilterChange: (value: TimeFilter | null) => void
+  timeFilterAnchor: Date
   timeFormat: (date: Date) => string
 }
+
+// ISO strings can differ in formatting (e.g. with/without milliseconds), so compare as instants
+const sameInstant = (a?: string, b?: string): boolean =>
+  a && b ? new Date(a).getTime() === new Date(b).getTime() : !a && !b
 
 const chartConfig = {
   validEvents: {
@@ -27,8 +33,9 @@ const chartConfig = {
 
 export function EventsChart({
   timelineData,
-  selectedBucket,
-  onBucketClick,
+  timeFilter,
+  onTimeFilterChange,
+  timeFilterAnchor,
   timeFormat,
 }: EventsChartProps) {
   const [barHovered, setBarHovered] = useState(false)
@@ -50,24 +57,39 @@ export function EventsChart({
       // Check if we actually have events at this time point
       if (data.validEvents > 0 || data.failedEvents > 0) {
         // Clicking on a bar with actual data - toggle selection
-        const bucketKey = `${data.bucketStart}|${data.bucketEnd}`
-        onBucketClick(selectedBucket === bucketKey ? null : bucketKey)
+        const isSelected =
+          timeFilter?.kind === 'absolute' &&
+          sameInstant(timeFilter.start, data.bucketStart) &&
+          sameInstant(timeFilter.end, data.bucketEnd)
+        onTimeFilterChange(
+          isSelected
+            ? null
+            : { kind: 'absolute', start: data.bucketStart, end: data.bucketEnd }
+        )
       } else {
         // Clicking on empty area (no events at this time) - reset selection
-        onBucketClick(null)
+        onTimeFilterChange(null)
       }
     } else {
       // Clicking on empty area - reset selection
-      onBucketClick(null)
+      onTimeFilterChange(null)
     }
   }
 
+  const selectedRange = useMemo(
+    () => (timeFilter ? resolveTimeFilter(timeFilter, timeFilterAnchor) : null),
+    [timeFilter, timeFilterAnchor]
+  )
+
   const getBarOpacity = (index: number): number => {
+    if (!selectedRange) return 0.8
     const data = chartData[index]
-    const bucketKey = `${data.bucketStart}|${data.bucketEnd}`
-    if (selectedBucket === bucketKey) return 1.0
-    if (selectedBucket && selectedBucket !== bucketKey) return 0.2
-    return 0.8
+    const overlaps = overlapsRange(
+      selectedRange,
+      new Date(data.bucketStart),
+      new Date(data.bucketEnd)
+    )
+    return overlaps ? 1.0 : 0.2
   }
 
   return (

--- a/ui/src/components/EventsChart.tsx
+++ b/ui/src/components/EventsChart.tsx
@@ -16,9 +16,12 @@ interface EventsChartProps {
   timeFormat: (date: Date) => string
 }
 
-// ISO strings can differ in formatting (e.g. with/without milliseconds), so compare as instants
-const sameInstant = (a?: string, b?: string): boolean =>
-  a && b ? new Date(a).getTime() === new Date(b).getTime() : !a && !b
+const sameInstant = (a: string, b: string): boolean =>
+  new Date(a).getTime() === new Date(b).getTime()
+
+const BAR_OPACITY = 0.8
+const BAR_OPACITY_IN_RANGE = 1
+const BAR_OPACITY_OUT_OF_RANGE = 0.2
 
 const chartConfig = {
   validEvents: {
@@ -51,45 +54,37 @@ export function EventsChart({
   }, [timelineData, timeFormat])
 
   const handleChartClick = (event: any) => {
-    if (event && event.activePayload && event.activePayload.length > 0) {
-      const data = event.activePayload[0].payload
-
-      // Check if we actually have events at this time point
-      if (data.validEvents > 0 || data.failedEvents > 0) {
-        // Clicking on a bar with actual data - toggle selection
-        const isSelected =
-          timeFilter?.kind === 'absolute' &&
-          sameInstant(timeFilter.start, data.bucketStart) &&
-          sameInstant(timeFilter.end, data.bucketEnd)
-        onTimeFilterChange(
-          isSelected
-            ? null
-            : { kind: 'absolute', start: data.bucketStart, end: data.bucketEnd }
-        )
-      } else {
-        // Clicking on empty area (no events at this time) - reset selection
-        onTimeFilterChange(null)
-      }
-    } else {
-      // Clicking on empty area - reset selection
+    const data = event?.activePayload?.[0]?.payload
+    // Clicking a bar toggles its bucket; clicking where there are no events clears the filter
+    if (!data || !(data.validEvents > 0 || data.failedEvents > 0)) {
       onTimeFilterChange(null)
+      return
     }
+    // A bucket selection always carries both bounds, so a one-sided filter isn't one
+    const isSelected =
+      timeFilter?.kind === 'absolute' &&
+      timeFilter.start !== undefined &&
+      timeFilter.end !== undefined &&
+      sameInstant(timeFilter.start, data.bucketStart) &&
+      sameInstant(timeFilter.end, data.bucketEnd)
+    onTimeFilterChange(
+      isSelected
+        ? null
+        : { kind: 'absolute', start: data.bucketStart, end: data.bucketEnd }
+    )
   }
 
-  const selectedRange = useMemo(
-    () => (timeFilter ? resolveTimeFilter(timeFilter, timeFilterAnchor) : null),
-    [timeFilter, timeFilterAnchor]
-  )
+  const selectedRange = timeFilter ? resolveTimeFilter(timeFilter, timeFilterAnchor) : null
 
   const getBarOpacity = (index: number): number => {
-    if (!selectedRange) return 0.8
+    if (!selectedRange) return BAR_OPACITY
     const data = chartData[index]
     const overlaps = overlapsRange(
       selectedRange,
       new Date(data.bucketStart),
       new Date(data.bucketEnd)
     )
-    return overlaps ? 1.0 : 0.2
+    return overlaps ? BAR_OPACITY_IN_RANGE : BAR_OPACITY_OUT_OF_RANGE
   }
 
   return (

--- a/ui/src/components/TimeRangeFilter.test.tsx
+++ b/ui/src/components/TimeRangeFilter.test.tsx
@@ -1,0 +1,264 @@
+// @vitest-environment jsdom
+import { useState } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { TimeRangeFilter } from './TimeRangeFilter'
+import { type TimeFilter } from '@/utils/time-filter'
+
+afterEach(cleanup)
+
+const localWallClock = (
+  year: number,
+  month: number,
+  day: number,
+  hours = 0,
+  minutes = 0,
+  seconds = 0,
+  ms = 0
+) => new Date(year, month - 1, day, hours, minutes, seconds, ms)
+
+const ANCHOR = localWallClock(2026, 3, 14, 12, 0)
+
+const wholeDay = (day: number) => ({
+  kind: 'absolute' as const,
+  start: localWallClock(2026, 3, day).toISOString(),
+  end: localWallClock(2026, 3, day, 23, 59, 59, 999).toISOString(),
+})
+
+function renderFilter(initial: TimeFilter | null = null) {
+  const onChange = vi.fn()
+  function Harness() {
+    const [value, setValue] = useState(initial)
+    return (
+      <TimeRangeFilter
+        value={value}
+        anchor={ANCHOR}
+        onChange={(next) => {
+          onChange(next)
+          setValue(next)
+        }}
+      />
+    )
+  }
+  render(<Harness />)
+  return onChange
+}
+
+const trigger = () => screen.getByRole('button', { expanded: false })
+const open = () => fireEvent.click(trigger())
+const day = (label: string) => screen.getByRole('button', { name: label })
+const preset = (minutes: number) =>
+  screen
+    .getAllByRole('button', { name: `Last ${minutes} min` })
+    .filter((button) => button.hasAttribute('aria-pressed'))[0]
+const from = () => screen.getByLabelText('From')
+const until = () => screen.getByLabelText('until')
+const isOpen = () => screen.queryByLabelText('From') !== null
+const highlightedDays = () =>
+  screen.queryAllByRole('button', { pressed: true }).map((button) => button.textContent)
+
+describe('TimeRangeFilter', () => {
+  it('reads as unfiltered and offers nothing to clear', () => {
+    renderFilter()
+    expect(trigger()).toHaveTextContent('Any time')
+    expect(screen.queryByLabelText('Clear time filter')).toBeNull()
+  })
+
+  it('describes the current filter on the trigger', () => {
+    renderFilter({
+      kind: 'absolute',
+      start: localWallClock(2026, 3, 14, 9, 0).toISOString(),
+      end: localWallClock(2026, 3, 14, 17, 30).toISOString(),
+    })
+    expect(trigger()).toHaveTextContent('Mar 14, 09:00 – 17:30')
+  })
+
+  it('opens on the trigger and offers the week ending today', () => {
+    renderFilter()
+    expect(isOpen()).toBe(false)
+    open()
+    expect(isOpen()).toBe(true)
+    expect(day('Mar 8')).toBeInTheDocument()
+    expect(day('Mar 13')).toBeInTheDocument()
+    expect(day('Today')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Mar 14' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Mar 7' })).toBeNull()
+  })
+
+  it('closes on Escape and on a click outside, but not on one inside', () => {
+    renderFilter()
+    open()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(isOpen()).toBe(false)
+
+    open()
+    fireEvent.mouseDown(day('Mar 13'))
+    expect(isOpen()).toBe(true)
+    fireEvent.mouseDown(document.body)
+    expect(isOpen()).toBe(false)
+  })
+
+  it('clears the filter and closes', () => {
+    const onChange = renderFilter({ kind: 'relative', minutes: 15 })
+    open()
+    fireEvent.click(screen.getByLabelText('Clear time filter'))
+    expect(onChange).toHaveBeenLastCalledWith(null)
+    expect(isOpen()).toBe(false)
+    expect(trigger()).toHaveTextContent('Any time')
+  })
+
+  describe('presets', () => {
+    it('picks a relative filter, and toggles it off when picked again', () => {
+      const onChange = renderFilter()
+      open()
+      fireEvent.click(preset(15))
+      expect(onChange).toHaveBeenLastCalledWith({ kind: 'relative', minutes: 15 })
+      expect(preset(15)).toHaveAttribute('aria-pressed', 'true')
+
+      fireEvent.click(preset(15))
+      expect(onChange).toHaveBeenLastCalledWith(null)
+      expect(preset(15)).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    it('switches between presets rather than clearing', () => {
+      const onChange = renderFilter({ kind: 'relative', minutes: 15 })
+      open()
+      fireEvent.click(preset(5))
+      expect(onChange).toHaveBeenLastCalledWith({ kind: 'relative', minutes: 5 })
+    })
+
+    it('shows the range a relative filter currently resolves to', () => {
+      renderFilter({ kind: 'relative', minutes: 15 })
+      open()
+      expect(from()).toHaveValue('11:45')
+      expect(until()).toHaveValue('')
+      expect(day('Today')).toHaveAttribute('aria-pressed', 'true')
+      expect(day('Mar 13')).toHaveAttribute('aria-pressed', 'false')
+    })
+  })
+
+  describe('the day strip', () => {
+    it('picks a whole day', () => {
+      const onChange = renderFilter()
+      open()
+      fireEvent.click(day('Mar 13'))
+      expect(onChange).toHaveBeenLastCalledWith(wholeDay(13))
+      expect(from()).toHaveValue('00:00')
+      expect(until()).toHaveValue('23:59')
+      expect(highlightedDays()).toEqual(['Mar 13'])
+    })
+
+    it('extends the selection back to an earlier day', () => {
+      const onChange = renderFilter()
+      open()
+      fireEvent.click(day('Mar 13'))
+      fireEvent.click(day('Mar 11'))
+      expect(onChange).toHaveBeenLastCalledWith({
+        kind: 'absolute',
+        start: wholeDay(11).start,
+        end: wholeDay(13).end,
+      })
+      expect(highlightedDays()).toEqual(['Mar 11', 'Mar 12', 'Mar 13'])
+    })
+
+    it('extends the selection forward to a later day', () => {
+      const onChange = renderFilter()
+      open()
+      fireEvent.click(day('Mar 11'))
+      fireEvent.click(day('Mar 13'))
+      expect(onChange).toHaveBeenLastCalledWith({
+        kind: 'absolute',
+        start: wholeDay(11).start,
+        end: wholeDay(13).end,
+      })
+    })
+
+    it('clears when the day of a whole-day selection is picked again', () => {
+      const onChange = renderFilter()
+      open()
+      fireEvent.click(day('Mar 13'))
+      fireEvent.click(day('Mar 13'))
+      expect(onChange).toHaveBeenLastCalledWith(null)
+      expect(highlightedDays()).toEqual([])
+    })
+
+    it('widens a part-day selection to the whole day before clearing it', () => {
+      const onChange = renderFilter(wholeDay(13))
+      open()
+      fireEvent.change(from(), { target: { value: '09:00' } })
+      fireEvent.click(day('Mar 13'))
+      expect(onChange).toHaveBeenLastCalledWith(wholeDay(13))
+      fireEvent.click(day('Mar 13'))
+      expect(onChange).toHaveBeenLastCalledWith(null)
+    })
+
+    it('carries the times over to the next day picked', () => {
+      const onChange = renderFilter(wholeDay(13))
+      open()
+      fireEvent.change(from(), { target: { value: '09:00' } })
+      fireEvent.change(until(), { target: { value: '17:00' } })
+      fireEvent.click(day('Mar 11'))
+      expect(onChange).toHaveBeenLastCalledWith({
+        kind: 'absolute',
+        start: localWallClock(2026, 3, 11, 9, 0).toISOString(),
+        end: localWallClock(2026, 3, 13, 17, 0).toISOString(),
+      })
+    })
+
+    it('does not carry over the times a relative filter happens to resolve to', () => {
+      const onChange = renderFilter({ kind: 'relative', minutes: 15 })
+      open()
+      fireEvent.click(day('Mar 13'))
+      expect(onChange).toHaveBeenLastCalledWith(wholeDay(13))
+    })
+  })
+
+  describe('the time fields', () => {
+    it('moves a bound within the selected day', () => {
+      const onChange = renderFilter(wholeDay(13))
+      open()
+      fireEvent.change(from(), { target: { value: '09:00' } })
+      expect(onChange).toHaveBeenLastCalledWith({
+        kind: 'absolute',
+        start: localWallClock(2026, 3, 13, 9, 0).toISOString(),
+        end: wholeDay(13).end,
+      })
+
+      fireEvent.change(until(), { target: { value: '17:00' } })
+      expect(onChange).toHaveBeenLastCalledWith({
+        kind: 'absolute',
+        start: localWallClock(2026, 3, 13, 9, 0).toISOString(),
+        end: localWallClock(2026, 3, 13, 17, 0).toISOString(),
+      })
+    })
+
+    it('ignores an incomplete value', () => {
+      const onChange = renderFilter(wholeDay(13))
+      open()
+      fireEvent.change(from(), { target: { value: '' } })
+      expect(onChange).not.toHaveBeenCalled()
+    })
+
+    it('freezes a relative filter into the range it resolved to', () => {
+      const onChange = renderFilter({ kind: 'relative', minutes: 15 })
+      open()
+      fireEvent.change(from(), { target: { value: '09:00' } })
+      expect(onChange).toHaveBeenLastCalledWith({
+        kind: 'absolute',
+        start: localWallClock(2026, 3, 14, 9, 0).toISOString(),
+        end: undefined,
+      })
+    })
+
+    it('allows an inverted range but highlights nothing', () => {
+      renderFilter(wholeDay(13))
+      open()
+      fireEvent.change(from(), { target: { value: '17:00' } })
+      fireEvent.change(until(), { target: { value: '09:00' } })
+      expect(from()).toHaveValue('17:00')
+      expect(until()).toHaveValue('09:00')
+      expect(highlightedDays()).toEqual([])
+    })
+  })
+})

--- a/ui/src/components/TimeRangeFilter.tsx
+++ b/ui/src/components/TimeRangeFilter.tsx
@@ -42,8 +42,9 @@ function TimeField({
       {label}
       <Input
         type="time"
-        // Chrome lays the value box out as a flex child filling the input, so
-        // centring what it shows takes more than text-align
+        // The value lives in a shadow tree (::-webkit-datetime-edit, holding the HH and MM
+        // segments) that Chrome lays out as a flex child of the input, so `text-align` on
+        // the input never reaches it. Centring means making that element the flex container.
         className="h-7 w-auto px-3 text-center [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-datetime-edit]:flex [&::-webkit-datetime-edit]:w-full [&::-webkit-datetime-edit]:justify-center"
         value={value}
         onChange={(e) => onChange(e.target.value)}
@@ -74,8 +75,6 @@ export function TimeRangeFilter({ value, onChange, anchor }: TimeRangeFilterProp
     }
   }, [open])
 
-  // Show a relative filter as the range it currently resolves to; editing the
-  // days or the time fields freezes it into that absolute range.
   const resolved = value ? resolveTimeFilter(value, anchor) : null
   const from = resolved?.start ? new Date(resolved.start) : undefined
   const to = resolved?.end ? new Date(resolved.end) : undefined
@@ -96,30 +95,30 @@ export function TimeRangeFilter({ value, onChange, anchor }: TimeRangeFilterProp
     // Times carry over between day picks, but a relative filter resolves to an
     // arbitrary "now", which makes a poor default for a whole day
     const absolute = value?.kind === 'absolute'
-    let startTime = (absolute && toTimeInput(from)) || DAY_START
-    let endTime = (absolute && toTimeInput(to)) || DAY_END
+    const carriedStart = (absolute && toTimeInput(from)) || DAY_START
+    const carriedEnd = (absolute && toTimeInput(to)) || DAY_END
 
     // Extend when a single day is already picked, otherwise start a new selection
     const extending = absolute && from && to && isSameDay(from, to) && !isSameDay(from, day)
     if (extending) {
       const [first, last] = day < from ? [day, from] : [from, day]
       emit(
-        combineDayAndTime(first, startTime, false),
-        combineDayAndTime(last, endTime, true)
+        combineDayAndTime(first, carriedStart, false),
+        combineDayAndTime(last, carriedEnd, true)
       )
       return
     }
     // Re-picking the day the selection sits on widens it to the whole day, then
     // clears it, the way presets and chart bars toggle off
     const alreadyOnDay = from && to && isSameDay(from, day) && isSameDay(to, day)
-    if (alreadyOnDay && startTime === DAY_START && endTime === DAY_END) {
+    if (alreadyOnDay && carriedStart === DAY_START && carriedEnd === DAY_END) {
       onChange(null)
       return
     }
-    if (alreadyOnDay || startTime >= endTime) {
-      startTime = DAY_START
-      endTime = DAY_END
-    }
+    const wholeDay = alreadyOnDay || carriedStart >= carriedEnd
+    const [startTime, endTime] = wholeDay
+      ? [DAY_START, DAY_END]
+      : [carriedStart, carriedEnd]
     emit(
       combineDayAndTime(day, startTime, false),
       combineDayAndTime(day, endTime, true)
@@ -127,8 +126,6 @@ export function TimeRangeFilter({ value, onChange, anchor }: TimeRangeFilterProp
   }
 
   const handleTimeChange = (part: 'start' | 'end', time: string) => {
-    // A time input reports "" for every incomplete value, which is every keystroke
-    // until both fields are filled — dropping the bound then would clear the filter
     if (!time) return
     const isEnd = part === 'end'
     const day = (isEnd ? to : from) ?? from ?? to ?? anchor

--- a/ui/src/components/TimeRangeFilter.tsx
+++ b/ui/src/components/TimeRangeFilter.tsx
@@ -4,15 +4,21 @@ import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import {
+  DAY_END,
+  DAY_START,
   LOCALE,
   STRIP_DAYS,
   TIME_PRESETS,
+  addDays,
+  combineDayAndTime,
   describeTimeFilter,
   formatDay,
   isSameDay,
   overlapsRange,
   presetLabel,
   resolveTimeFilter,
+  startOfDay,
+  toTimeInput,
   type TimeFilter,
 } from '@/utils/time-filter'
 
@@ -20,38 +26,6 @@ type TimeRangeFilterProps = {
   value: TimeFilter | null
   onChange: (value: TimeFilter | null) => void
   anchor: Date
-}
-
-const DAY_START = '00:00'
-const DAY_END = '23:59'
-
-const pad = (n: number) => String(n).padStart(2, '0')
-
-function toTimeInput(date?: Date): string {
-  return date ? `${pad(date.getHours())}:${pad(date.getMinutes())}` : ''
-}
-
-function startOfDay(date: Date): Date {
-  const day = new Date(date)
-  day.setHours(0, 0, 0, 0)
-  return day
-}
-
-function addDays(date: Date, count: number): Date {
-  const shifted = new Date(date)
-  shifted.setDate(date.getDate() + count)
-  return shifted
-}
-
-// The day strip picks the day, the time fields pick the time within it. The end
-// bound is exclusive, so as an end 23:59 has to mean the very end of the day or a
-// whole-day selection would drop its final minute.
-function combine(day: Date, time: string, isEnd: boolean): string {
-  const [hours, minutes] = time.split(':').map(Number)
-  const endOfDay = isEnd && time === DAY_END
-  const combined = new Date(day)
-  combined.setHours(hours || 0, minutes || 0, endOfDay ? 59 : 0, endOfDay ? 999 : 0)
-  return combined.toISOString()
 }
 
 function TimeField({
@@ -115,14 +89,7 @@ export function TimeRangeFilter({ value, onChange, anchor }: TimeRangeFilterProp
     resolved ? overlapsRange(resolved, day, addDays(day, 1)) : false
 
   const emit = (start?: string, end?: string) => {
-    // A start past the end matches nothing and nothing in the UI says why, so keep
-    // the pair ordered instead (both are ISO strings, which sort chronologically)
-    const ordered = start && end && start > end ? [end, start] : [start, end]
-    onChange(
-      ordered[0] || ordered[1]
-        ? { kind: 'absolute', start: ordered[0], end: ordered[1] }
-        : null
-    )
+    onChange(start || end ? { kind: 'absolute', start, end } : null)
   }
 
   const selectDay = (day: Date) => {
@@ -136,7 +103,10 @@ export function TimeRangeFilter({ value, onChange, anchor }: TimeRangeFilterProp
     const extending = absolute && from && to && isSameDay(from, to) && !isSameDay(from, day)
     if (extending) {
       const [first, last] = day < from ? [day, from] : [from, day]
-      emit(combine(first, startTime, false), combine(last, endTime, true))
+      emit(
+        combineDayAndTime(first, startTime, false),
+        combineDayAndTime(last, endTime, true)
+      )
       return
     }
     // Re-picking the day the selection sits on widens it to the whole day, then
@@ -150,7 +120,10 @@ export function TimeRangeFilter({ value, onChange, anchor }: TimeRangeFilterProp
       startTime = DAY_START
       endTime = DAY_END
     }
-    emit(combine(day, startTime, false), combine(day, endTime, true))
+    emit(
+      combineDayAndTime(day, startTime, false),
+      combineDayAndTime(day, endTime, true)
+    )
   }
 
   const handleTimeChange = (part: 'start' | 'end', time: string) => {
@@ -159,7 +132,7 @@ export function TimeRangeFilter({ value, onChange, anchor }: TimeRangeFilterProp
     if (!time) return
     const isEnd = part === 'end'
     const day = (isEnd ? to : from) ?? from ?? to ?? anchor
-    const bound = combine(day, time, isEnd)
+    const bound = combineDayAndTime(day, time, isEnd)
     emit(isEnd ? resolved?.start : bound, isEnd ? bound : resolved?.end)
   }
 

--- a/ui/src/components/TimeRangeFilter.tsx
+++ b/ui/src/components/TimeRangeFilter.tsx
@@ -1,0 +1,273 @@
+import { useEffect, useRef, useState } from 'react'
+import { X, ChevronDown } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import {
+  LOCALE,
+  STRIP_DAYS,
+  TIME_PRESETS,
+  describeTimeFilter,
+  formatDay,
+  isSameDay,
+  overlapsRange,
+  presetLabel,
+  resolveTimeFilter,
+  type TimeFilter,
+} from '@/utils/time-filter'
+
+type TimeRangeFilterProps = {
+  value: TimeFilter | null
+  onChange: (value: TimeFilter | null) => void
+  anchor: Date
+}
+
+const DAY_START = '00:00'
+const DAY_END = '23:59'
+
+const pad = (n: number) => String(n).padStart(2, '0')
+
+function toTimeInput(date?: Date): string {
+  return date ? `${pad(date.getHours())}:${pad(date.getMinutes())}` : ''
+}
+
+function startOfDay(date: Date): Date {
+  const day = new Date(date)
+  day.setHours(0, 0, 0, 0)
+  return day
+}
+
+function addDays(date: Date, count: number): Date {
+  const shifted = new Date(date)
+  shifted.setDate(date.getDate() + count)
+  return shifted
+}
+
+// The day strip picks the day, the time fields pick the time within it. The end
+// bound is exclusive, so as an end 23:59 has to mean the very end of the day or a
+// whole-day selection would drop its final minute.
+function combine(day: Date, time: string, isEnd: boolean): string {
+  const [hours, minutes] = time.split(':').map(Number)
+  const endOfDay = isEnd && time === DAY_END
+  const combined = new Date(day)
+  combined.setHours(hours || 0, minutes || 0, endOfDay ? 59 : 0, endOfDay ? 999 : 0)
+  return combined.toISOString()
+}
+
+function TimeField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string
+  value: string
+  onChange: (time: string) => void
+}) {
+  return (
+    <label className="flex items-center gap-2">
+      {label}
+      <Input
+        type="time"
+        // Chrome lays the value box out as a flex child filling the input, so
+        // centring what it shows takes more than text-align
+        className="h-7 w-auto px-3 text-center [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-datetime-edit]:flex [&::-webkit-datetime-edit]:w-full [&::-webkit-datetime-edit]:justify-center"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </label>
+  )
+}
+
+export function TimeRangeFilter({ value, onChange, anchor }: TimeRangeFilterProps) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onMouseDown = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  // Show a relative filter as the range it currently resolves to; editing the
+  // days or the time fields freezes it into that absolute range.
+  const resolved = value ? resolveTimeFilter(value, anchor) : null
+  const from = resolved?.start ? new Date(resolved.start) : undefined
+  const to = resolved?.end ? new Date(resolved.end) : undefined
+
+  const today = startOfDay(anchor)
+  const days = Array.from({ length: STRIP_DAYS }, (_, i) =>
+    addDays(today, i - (STRIP_DAYS - 1))
+  )
+
+  const coversDay = (day: Date) =>
+    resolved ? overlapsRange(resolved, day, addDays(day, 1)) : false
+
+  const emit = (start?: string, end?: string) => {
+    // A start past the end matches nothing and nothing in the UI says why, so keep
+    // the pair ordered instead (both are ISO strings, which sort chronologically)
+    const ordered = start && end && start > end ? [end, start] : [start, end]
+    onChange(
+      ordered[0] || ordered[1]
+        ? { kind: 'absolute', start: ordered[0], end: ordered[1] }
+        : null
+    )
+  }
+
+  const selectDay = (day: Date) => {
+    // Times carry over between day picks, but a relative filter resolves to an
+    // arbitrary "now", which makes a poor default for a whole day
+    const absolute = value?.kind === 'absolute'
+    let startTime = (absolute && toTimeInput(from)) || DAY_START
+    let endTime = (absolute && toTimeInput(to)) || DAY_END
+
+    // Extend when a single day is already picked, otherwise start a new selection
+    const extending = absolute && from && to && isSameDay(from, to) && !isSameDay(from, day)
+    if (extending) {
+      const [first, last] = day < from ? [day, from] : [from, day]
+      emit(combine(first, startTime, false), combine(last, endTime, true))
+      return
+    }
+    // Re-picking the day the selection sits on widens it to the whole day, then
+    // clears it, the way presets and chart bars toggle off
+    const alreadyOnDay = from && to && isSameDay(from, day) && isSameDay(to, day)
+    if (alreadyOnDay && startTime === DAY_START && endTime === DAY_END) {
+      onChange(null)
+      return
+    }
+    if (alreadyOnDay || startTime >= endTime) {
+      startTime = DAY_START
+      endTime = DAY_END
+    }
+    emit(combine(day, startTime, false), combine(day, endTime, true))
+  }
+
+  const handleTimeChange = (part: 'start' | 'end', time: string) => {
+    // A time input reports "" for every incomplete value, which is every keystroke
+    // until both fields are filled — dropping the bound then would clear the filter
+    if (!time) return
+    const isEnd = part === 'end'
+    const day = (isEnd ? to : from) ?? from ?? to ?? anchor
+    const bound = combine(day, time, isEnd)
+    emit(isEnd ? resolved?.start : bound, isEnd ? bound : resolved?.end)
+  }
+
+  const selectPreset = (minutes: number) => {
+    const isActive = value?.kind === 'relative' && value.minutes === minutes
+    onChange(isActive ? null : { kind: 'relative', minutes })
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative inline-flex h-8 items-center rounded-md border bg-background text-xs font-light"
+    >
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        onClick={() => setOpen(!open)}
+        className={cn(
+          'flex h-full cursor-pointer items-center gap-1 px-3 whitespace-nowrap',
+          !value && 'text-gray-500'
+        )}
+      >
+        {describeTimeFilter(value)}
+        {!value && <ChevronDown className="h-3 w-3" />}
+      </button>
+      {value && (
+        <button
+          type="button"
+          aria-label="Clear time filter"
+          className="mr-2 cursor-pointer rounded-sm p-0.5 hover:bg-gray-200"
+          onClick={() => {
+            onChange(null)
+            setOpen(false)
+          }}
+        >
+          <X className="h-3 w-3" />
+        </button>
+      )}
+
+      {open && (
+        <div className="absolute top-full left-0 z-50 mt-1 w-max bg-white border rounded-md shadow-lg p-3">
+          <div className="flex gap-1">
+            {TIME_PRESETS.map((minutes) => (
+              <Button
+                key={minutes}
+                variant={
+                  value?.kind === 'relative' && value.minutes === minutes
+                    ? 'outlineActive'
+                    : 'outline'
+                }
+                size="sm"
+                className="flex-1 text-xs font-light h-7 px-2"
+                aria-pressed={value?.kind === 'relative' && value.minutes === minutes}
+                onClick={() => selectPreset(minutes)}
+              >
+                {presetLabel(minutes)}
+              </Button>
+            ))}
+          </div>
+
+          <div className="my-3 border-t" />
+
+          <div className="flex">
+            {days.map((day, index) => {
+              const selected = coversDay(day)
+              const isFirst = selected && !(index > 0 && coversDay(days[index - 1]))
+              const isLast =
+                selected && !(index < days.length - 1 && coversDay(days[index + 1]))
+              const isToday = index === days.length - 1
+              return (
+                <button
+                  key={day.toISOString()}
+                  type="button"
+                  title={day.toLocaleDateString(LOCALE)}
+                  aria-pressed={selected}
+                  onClick={() => selectDay(day)}
+                  className={cn(
+                    'flex-auto cursor-pointer px-1.5 py-1.5 text-xs font-light whitespace-nowrap',
+                    selected
+                      ? cn(
+                          isFirst || isLast ? 'bg-focus/70' : 'bg-focus/25',
+                          isFirst && 'rounded-l-md',
+                          isLast && 'rounded-r-md'
+                        )
+                      : 'rounded-md hover:bg-gray-100'
+                  )}
+                >
+                  {isToday ? 'Today' : formatDay(day)}
+                </button>
+              )
+            })}
+          </div>
+
+          <div className="mt-3 flex items-center justify-evenly text-xs font-light">
+            <TimeField
+              label="From"
+              value={toTimeInput(from)}
+              onChange={(time) => handleTimeChange('start', time)}
+            />
+            <TimeField
+              label="until"
+              value={toTimeInput(to)}
+              onChange={(time) => handleTimeChange('end', time)}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/hooks/useColumnManager.ts
+++ b/ui/src/hooks/useColumnManager.ts
@@ -2,11 +2,15 @@ import { useState, useMemo } from 'react'
 
 import type { ColumnFiltersState, OnChangeFn } from '@tanstack/react-table'
 import { type ColumnMetadata, createColumnMetadata } from '@/utils/column-metadata'
+import { isFixedColumn } from '@/utils/fixed-columns'
 
 const STORAGE_KEY = 'snowplow-micro-selected-columns'
 
 // Default column configuration
-const DEFAULT_COLUMNS = ['collector_tstamp', 'app_id', 'event_name']
+const DEFAULT_COLUMNS = ['app_id', 'event_name']
+
+// Columns backing the fixed ones are never part of the user's selection
+const selectable = (columns: string[]) => columns.filter((c) => !isFixedColumn(c))
 
 /**
  * Save selected columns to localStorage
@@ -64,8 +68,8 @@ export function useColumnManager({
   initialColumns,
   persistToStorage = true,
 }: UseColumnManagerProps): UseColumnManagerReturn {
-  const [selectedColumnNames, setSelectedColumnNames] = useState<string[]>(
-    initialColumns ?? loadSelectedColumns()
+  const [selectedColumnNames, setSelectedColumnNames] = useState<string[]>(() =>
+    selectable(initialColumns ?? loadSelectedColumns())
   )
 
   const selectedColumns = useMemo(() => {
@@ -83,12 +87,9 @@ export function useColumnManager({
       ...availableColumnNames,
     ])
 
-    // Remove failure entity, br_ fields, and all their nested fields
-    const filteredColumnNames = Array.from(set).filter(
-      (columnName) =>
-        !columnName.startsWith(
-          'contexts_com_snowplowanalytics_snowplow_failure_1'
-        ) && !columnName.startsWith('br_')
+    // Remove the fixed columns, br_ fields, and all their nested fields
+    const filteredColumnNames = selectable(Array.from(set)).filter(
+      (columnName) => !columnName.startsWith('br_')
     )
 
     return filteredColumnNames.map(createColumnMetadata)

--- a/ui/src/hooks/useColumnManager.ts
+++ b/ui/src/hooks/useColumnManager.ts
@@ -9,7 +9,6 @@ const STORAGE_KEY = 'snowplow-micro-selected-columns'
 // Default column configuration
 const DEFAULT_COLUMNS = ['app_id', 'event_name']
 
-// Columns backing the fixed ones are never part of the user's selection
 const selectable = (columns: string[]) => columns.filter((c) => !isFixedColumn(c))
 
 /**

--- a/ui/src/utils/column-generation.tsx
+++ b/ui/src/utils/column-generation.tsx
@@ -12,8 +12,6 @@ import { hasFailureData } from './event-utils'
 
 export type EventColumnMeta = {
   eventStatusFilter?: boolean
-  // Marks a filter cell driven by props rather than by the table's own filter
-  // state, because the time filter is shared with the charts
   eventTimeFilter?: boolean
   distinctValues?: string[]
 }

--- a/ui/src/utils/column-generation.tsx
+++ b/ui/src/utils/column-generation.tsx
@@ -1,4 +1,4 @@
-import type { ColumnDef } from '@tanstack/react-table'
+import type { Column, ColumnDef } from '@tanstack/react-table'
 import { Button } from '@/components/ui/button'
 import { ArrowUp, ArrowDown, Eye, Check, X } from 'lucide-react'
 import type { Event, ColumnStats } from '@/services/api'
@@ -7,11 +7,43 @@ import { TruncatedCell } from '@/components/TruncatedCell'
 import { TruncatedColumnName } from '@/components/TruncatedColumnName'
 import { truncateJsonForDisplay } from './json-fields'
 import { type ColumnMetadata } from './column-metadata'
+import { FAILURE_COLUMN, TIMESTAMP_COLUMN } from './fixed-columns'
 import { hasFailureData } from './event-utils'
 
 export type EventColumnMeta = {
   eventStatusFilter?: boolean
+  // Marks a filter cell driven by props rather than by the table's own filter
+  // state, because the time filter is shared with the charts
+  eventTimeFilter?: boolean
   distinctValues?: string[]
+}
+
+function SortableHeader({
+  column,
+  children,
+}: {
+  column: Column<Event>
+  children: React.ReactNode
+}) {
+  return (
+    <Button
+      variant="ghost"
+      onClick={() => column.toggleSorting(column.getIsSorted() !== 'desc')}
+      className="h-8 px-2 flex items-center group"
+      title="Sort column"
+    >
+      {children}
+      <div className="ml-2">
+        {column.getIsSorted() === 'asc' ? (
+          <ArrowUp className="h-4 w-4" />
+        ) : column.getIsSorted() === 'desc' ? (
+          <ArrowDown className="h-4 w-4" />
+        ) : (
+          <ArrowDown className="h-4 w-4 opacity-0 group-hover:opacity-100 transition-opacity" />
+        )}
+      </div>
+    </Button>
+  )
 }
 
 export type EventColumnDef = ColumnDef<Event> & {
@@ -30,7 +62,7 @@ export function generateColumns(
 ): EventColumnDef[] {
   const columns: EventColumnDef[] = []
 
-  // Pinned status column
+  // Fixed status column
   columns.push({
     id: 'status',
     accessorFn: (row) => (hasFailureData(row) ? 'failed' : 'valid'),
@@ -54,8 +86,7 @@ export function generateColumns(
         )
       }
 
-      const failureData =
-        row.original.contexts_com_snowplowanalytics_snowplow_failure_1
+      const failureData = row.original[FAILURE_COLUMN]
       if (Array.isArray(failureData) && onJsonCellToggle) {
         const failureCount = failureData.length
         return (
@@ -94,6 +125,28 @@ export function generateColumns(
     enableColumnFilter: true,
   })
 
+  // Fixed timestamp column, carrying the time filter
+  columns.push({
+    id: TIMESTAMP_COLUMN,
+    accessorFn: (row) => row[TIMESTAMP_COLUMN],
+    meta: {
+      eventTimeFilter: true,
+    },
+    header: ({ column }) => (
+      <SortableHeader column={column}>{TIMESTAMP_COLUMN}</SortableHeader>
+    ),
+    cell: ({ getValue }) => {
+      const value = getValue()
+      return (
+        <div className="px-2 py-1">
+          {value === undefined ? '' : new Date(value as string).toLocaleString()}
+        </div>
+      )
+    },
+    enableSorting: true,
+    enableColumnFilter: false,
+  })
+
   // Add selected columns
   selectedColumns.forEach((columnMetadata, index) => {
     const { name: fieldName } = columnMetadata
@@ -119,25 +172,9 @@ export function generateColumns(
                 columnMetadata={columnMetadata}
               />
             ) : (
-              <Button
-                variant="ghost"
-                onClick={() =>
-                  column.toggleSorting(column.getIsSorted() !== 'desc')
-                }
-                className="h-8 px-2 flex items-center group"
-                title="Sort column"
-              >
+              <SortableHeader column={column}>
                 <TruncatedColumnName columnMetadata={columnMetadata} />
-                <div className="ml-2">
-                  {column.getIsSorted() === 'asc' ? (
-                    <ArrowUp className="h-4 w-4" />
-                  ) : column.getIsSorted() === 'desc' ? (
-                    <ArrowDown className="h-4 w-4" />
-                  ) : (
-                    <ArrowDown className="h-4 w-4 opacity-0 group-hover:opacity-100 transition-opacity" />
-                  )}
-                </div>
-              </Button>
+              </SortableHeader>
             )}
           </DraggableColumn>
         )

--- a/ui/src/utils/event-utils.ts
+++ b/ui/src/utils/event-utils.ts
@@ -1,10 +1,11 @@
 import type { Event } from '@/services/api'
+import { FAILURE_COLUMN } from './fixed-columns'
 
 /**
  * Check if an event has failure data
  */
 export function hasFailureData(event: Event): boolean {
-  const failureData = event.contexts_com_snowplowanalytics_snowplow_failure_1
+  const failureData = event[FAILURE_COLUMN]
   return (
     failureData !== undefined &&
     failureData !== null &&

--- a/ui/src/utils/fixed-columns.ts
+++ b/ui/src/utils/fixed-columns.ts
@@ -1,0 +1,14 @@
+// The event fields behind the two fixed columns: Status is derived from the failure
+// entity, and the timestamp column carries the time filter. Neither is offered in the
+// column picker; selections persisted or shared before they became fixed may still
+// mention them, and those references are ignored.
+export const TIMESTAMP_COLUMN = 'collector_tstamp'
+export const FAILURE_COLUMN = 'contexts_com_snowplowanalytics_snowplow_failure_1'
+
+const FIXED_COLUMNS = [TIMESTAMP_COLUMN, FAILURE_COLUMN]
+
+// A nested field of a fixed column (`<name>.<field>`) is fixed along with it
+export const isFixedColumn = (columnName: string): boolean =>
+  FIXED_COLUMNS.some(
+    (fixed) => columnName === fixed || columnName.startsWith(`${fixed}.`)
+  )

--- a/ui/src/utils/fixed-columns.ts
+++ b/ui/src/utils/fixed-columns.ts
@@ -1,13 +1,8 @@
-// The event fields behind the two fixed columns: Status is derived from the failure
-// entity, and the timestamp column carries the time filter. Neither is offered in the
-// column picker; selections persisted or shared before they became fixed may still
-// mention them, and those references are ignored.
 export const TIMESTAMP_COLUMN = 'collector_tstamp'
 export const FAILURE_COLUMN = 'contexts_com_snowplowanalytics_snowplow_failure_1'
 
 const FIXED_COLUMNS = [TIMESTAMP_COLUMN, FAILURE_COLUMN]
 
-// A nested field of a fixed column (`<name>.<field>`) is fixed along with it
 export const isFixedColumn = (columnName: string): boolean =>
   FIXED_COLUMNS.some(
     (fixed) => columnName === fixed || columnName.startsWith(`${fixed}.`)

--- a/ui/src/utils/time-filter.test.ts
+++ b/ui/src/utils/time-filter.test.ts
@@ -16,7 +16,7 @@ import {
 
 // Local wall clock, which is what the day strip and the time inputs speak. Expectations
 // are built the same way rather than as ISO literals, so they hold in any zone.
-const local = (
+const localWallClock = (
   year: number,
   month: number,
   day: number,
@@ -28,15 +28,15 @@ const local = (
 
 describe('combineDayAndTime', () => {
   it('takes the day from the date and the time from the string', () => {
-    const day = local(2026, 3, 14, 17, 45, 30, 123)
+    const day = localWallClock(2026, 3, 14, 17, 45, 30, 123)
     expect(combineDayAndTime(day, '09:05', false)).toBe(
-      local(2026, 3, 14, 9, 5).toISOString()
+      localWallClock(2026, 3, 14, 9, 5).toISOString()
     )
   })
 
   it('zeroes seconds and milliseconds so a bound never lands mid-minute', () => {
     const combined = new Date(
-      combineDayAndTime(local(2026, 3, 14, 0, 0, 42, 7), '09:05', false)
+      combineDayAndTime(localWallClock(2026, 3, 14, 0, 0, 42, 7), '09:05', false)
     )
     expect(combined.getSeconds()).toBe(0)
     expect(combined.getMilliseconds()).toBe(0)
@@ -44,44 +44,44 @@ describe('combineDayAndTime', () => {
 
   // The bound is exclusive, so a plain 23:59 would cut the day's last minute
   it('stretches 23:59 as an end to the end of that minute', () => {
-    expect(combineDayAndTime(local(2026, 3, 14), DAY_END, true)).toBe(
-      local(2026, 3, 14, 23, 59, 59, 999).toISOString()
+    expect(combineDayAndTime(localWallClock(2026, 3, 14), DAY_END, true)).toBe(
+      localWallClock(2026, 3, 14, 23, 59, 59, 999).toISOString()
     )
   })
 
   it('stays within the day it was given', () => {
-    const end = new Date(combineDayAndTime(local(2026, 3, 14), DAY_END, true))
-    expect(isSameDay(end, local(2026, 3, 14))).toBe(true)
+    const end = new Date(combineDayAndTime(localWallClock(2026, 3, 14), DAY_END, true))
+    expect(isSameDay(end, localWallClock(2026, 3, 14))).toBe(true)
     expect(toTimeInput(end)).toBe(DAY_END)
   })
 
   it('does not stretch 23:59 when it is a start', () => {
-    expect(combineDayAndTime(local(2026, 3, 14), DAY_END, false)).toBe(
-      local(2026, 3, 14, 23, 59).toISOString()
+    expect(combineDayAndTime(localWallClock(2026, 3, 14), DAY_END, false)).toBe(
+      localWallClock(2026, 3, 14, 23, 59).toISOString()
     )
   })
 
   it('leaves every other end time on the minute', () => {
-    expect(combineDayAndTime(local(2026, 3, 14), '23:58', true)).toBe(
-      local(2026, 3, 14, 23, 58).toISOString()
+    expect(combineDayAndTime(localWallClock(2026, 3, 14), '23:58', true)).toBe(
+      localWallClock(2026, 3, 14, 23, 58).toISOString()
     )
-    expect(combineDayAndTime(local(2026, 3, 14), DAY_START, true)).toBe(
-      local(2026, 3, 14).toISOString()
+    expect(combineDayAndTime(localWallClock(2026, 3, 14), DAY_START, true)).toBe(
+      localWallClock(2026, 3, 14).toISOString()
     )
   })
 
   it('falls back to midnight for an unparseable time', () => {
-    expect(combineDayAndTime(local(2026, 3, 14), '', false)).toBe(
-      local(2026, 3, 14).toISOString()
+    expect(combineDayAndTime(localWallClock(2026, 3, 14), '', false)).toBe(
+      localWallClock(2026, 3, 14).toISOString()
     )
   })
 })
 
 describe('toTimeInput', () => {
   it('pads to the HH:MM an <input type="time"> expects', () => {
-    expect(toTimeInput(local(2026, 3, 14, 9, 5))).toBe('09:05')
-    expect(toTimeInput(local(2026, 3, 14, 0, 0))).toBe('00:00')
-    expect(toTimeInput(local(2026, 3, 14, 23, 59))).toBe('23:59')
+    expect(toTimeInput(localWallClock(2026, 3, 14, 9, 5))).toBe('09:05')
+    expect(toTimeInput(localWallClock(2026, 3, 14, 0, 0))).toBe('00:00')
+    expect(toTimeInput(localWallClock(2026, 3, 14, 23, 59))).toBe('23:59')
   })
 
   it('is empty without a date, which blanks the field', () => {
@@ -91,7 +91,7 @@ describe('toTimeInput', () => {
   // The popover reads its fields back off the bounds it emitted, so the pair has to
   // round-trip or picking a second day would move the times
   it('round-trips a whole-day selection', () => {
-    const day = local(2026, 3, 14)
+    const day = localWallClock(2026, 3, 14)
     const start = new Date(combineDayAndTime(day, DAY_START, false))
     const end = new Date(combineDayAndTime(day, DAY_END, true))
     expect([toTimeInput(start), toTimeInput(end)]).toEqual([DAY_START, DAY_END])
@@ -100,44 +100,44 @@ describe('toTimeInput', () => {
 
 describe('startOfDay', () => {
   it('clears the time without touching the original', () => {
-    const original = local(2026, 3, 14, 17, 45, 30, 123)
-    expect(startOfDay(original)).toEqual(local(2026, 3, 14))
-    expect(original).toEqual(local(2026, 3, 14, 17, 45, 30, 123))
+    const original = localWallClock(2026, 3, 14, 17, 45, 30, 123)
+    expect(startOfDay(original)).toEqual(localWallClock(2026, 3, 14))
+    expect(original).toEqual(localWallClock(2026, 3, 14, 17, 45, 30, 123))
   })
 })
 
 describe('addDays', () => {
   it('crosses month and year boundaries', () => {
-    expect(addDays(local(2026, 1, 31), 1)).toEqual(local(2026, 2, 1))
-    expect(addDays(local(2026, 12, 31), 1)).toEqual(local(2027, 1, 1))
-    expect(addDays(local(2026, 3, 1), -1)).toEqual(local(2026, 2, 28))
+    expect(addDays(localWallClock(2026, 1, 31), 1)).toEqual(localWallClock(2026, 2, 1))
+    expect(addDays(localWallClock(2026, 12, 31), 1)).toEqual(localWallClock(2027, 1, 1))
+    expect(addDays(localWallClock(2026, 3, 1), -1)).toEqual(localWallClock(2026, 2, 28))
   })
 
   it('lands on Feb 29 in a leap year', () => {
-    expect(addDays(local(2024, 2, 28), 1)).toEqual(local(2024, 2, 29))
+    expect(addDays(localWallClock(2024, 2, 28), 1)).toEqual(localWallClock(2024, 2, 29))
   })
 
   it('does not mutate its argument', () => {
-    const original = local(2026, 3, 14)
+    const original = localWallClock(2026, 3, 14)
     addDays(original, 5)
-    expect(original).toEqual(local(2026, 3, 14))
+    expect(original).toEqual(localWallClock(2026, 3, 14))
   })
 
   // How the day strip is built: today last, the six preceding days before it
   it('builds a contiguous strip ending today', () => {
-    const today = local(2026, 3, 1)
+    const today = localWallClock(2026, 3, 1)
     const strip = Array.from({ length: 7 }, (_, i) => addDays(today, i - 6))
-    expect(strip[0]).toEqual(local(2026, 2, 23))
+    expect(strip[0]).toEqual(localWallClock(2026, 2, 23))
     expect(strip[6]).toEqual(today)
   })
 })
 
 describe('isSameDay', () => {
   it('compares the day, not the distance', () => {
-    expect(isSameDay(local(2026, 3, 14, 0, 0), local(2026, 3, 14, 23, 59, 59, 999))).toBe(
+    expect(isSameDay(localWallClock(2026, 3, 14, 0, 0), localWallClock(2026, 3, 14, 23, 59, 59, 999))).toBe(
       true
     )
-    expect(isSameDay(local(2026, 3, 14, 23, 59), local(2026, 3, 15, 0, 0))).toBe(false)
+    expect(isSameDay(localWallClock(2026, 3, 14, 23, 59), localWallClock(2026, 3, 15, 0, 0))).toBe(false)
   })
 })
 
@@ -222,18 +222,18 @@ describe('overlapsRange', () => {
 
 describe('formatMinute', () => {
   it('uses a 24-hour clock', () => {
-    expect(formatMinute(local(2026, 3, 14, 13, 5))).toBe('13:05')
+    expect(formatMinute(localWallClock(2026, 3, 14, 13, 5))).toBe('13:05')
   })
 
   // `hour12: false` resolves to h24 on some ICU builds, which writes midnight as 24:00
   // without rolling the date back, so the same label means two different days
   it('writes midnight as 00:00, not 24:00', () => {
-    expect(formatMinute(local(2026, 3, 14, 0, 0))).toBe('00:00')
-    expect(formatMinute(local(2026, 3, 14, 0, 30))).toBe('00:30')
+    expect(formatMinute(localWallClock(2026, 3, 14, 0, 0))).toBe('00:00')
+    expect(formatMinute(localWallClock(2026, 3, 14, 0, 30))).toBe('00:30')
   })
 
   it('writes the last minute of the day as 23:59', () => {
-    expect(formatMinute(local(2026, 3, 14, 23, 59))).toBe('23:59')
+    expect(formatMinute(localWallClock(2026, 3, 14, 23, 59))).toBe('23:59')
   })
 })
 
@@ -251,8 +251,8 @@ describe('describeTimeFilter', () => {
     expect(
       describeTimeFilter({
         kind: 'absolute',
-        start: local(2026, 3, 14, 9, 0).toISOString(),
-        end: local(2026, 3, 14, 17, 30).toISOString(),
+        start: localWallClock(2026, 3, 14, 9, 0).toISOString(),
+        end: localWallClock(2026, 3, 14, 17, 30).toISOString(),
       })
     ).toBe('Mar 14, 09:00 – 17:30')
   })
@@ -261,14 +261,14 @@ describe('describeTimeFilter', () => {
     expect(
       describeTimeFilter({
         kind: 'absolute',
-        start: local(2026, 3, 14, 9, 0).toISOString(),
-        end: local(2026, 3, 15, 17, 30).toISOString(),
+        start: localWallClock(2026, 3, 14, 9, 0).toISOString(),
+        end: localWallClock(2026, 3, 15, 17, 30).toISOString(),
       })
     ).toBe('Mar 14, 09:00 – Mar 15, 17:30')
   })
 
   it('describes a whole day by its own date, not the next one', () => {
-    const day = local(2026, 3, 14)
+    const day = localWallClock(2026, 3, 14)
     expect(
       describeTimeFilter({
         kind: 'absolute',
@@ -279,7 +279,7 @@ describe('describeTimeFilter', () => {
   })
 
   it('describes a one-sided range by the bound it has', () => {
-    const bound = local(2026, 3, 14, 9, 0).toISOString()
+    const bound = localWallClock(2026, 3, 14, 9, 0).toISOString()
     expect(describeTimeFilter({ kind: 'absolute', start: bound })).toBe(
       'After Mar 14, 09:00'
     )

--- a/ui/src/utils/time-filter.test.ts
+++ b/ui/src/utils/time-filter.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DAY_END,
+  DAY_START,
+  MAX_RELATIVE_MINUTES,
+  addDays,
+  combineDayAndTime,
+  describeTimeFilter,
+  isSameDay,
+  overlapsRange,
+  resolveTimeFilter,
+  startOfDay,
+  toTimeInput,
+} from './time-filter'
+
+// Local wall clock, which is what the day strip and the time inputs speak. Expectations
+// are built the same way rather than as ISO literals, so they hold in any zone.
+const local = (
+  year: number,
+  month: number,
+  day: number,
+  hours = 0,
+  minutes = 0,
+  seconds = 0,
+  ms = 0
+) => new Date(year, month - 1, day, hours, minutes, seconds, ms)
+
+describe('combineDayAndTime', () => {
+  it('takes the day from the date and the time from the string', () => {
+    const day = local(2026, 3, 14, 17, 45, 30, 123)
+    expect(combineDayAndTime(day, '09:05', false)).toBe(
+      local(2026, 3, 14, 9, 5).toISOString()
+    )
+  })
+
+  it('zeroes seconds and milliseconds so a bound never lands mid-minute', () => {
+    const combined = new Date(
+      combineDayAndTime(local(2026, 3, 14, 0, 0, 42, 7), '09:05', false)
+    )
+    expect(combined.getSeconds()).toBe(0)
+    expect(combined.getMilliseconds()).toBe(0)
+  })
+
+  // The bound is exclusive, so a plain 23:59 would cut the day's last minute
+  it('stretches 23:59 as an end to the end of that minute', () => {
+    expect(combineDayAndTime(local(2026, 3, 14), DAY_END, true)).toBe(
+      local(2026, 3, 14, 23, 59, 59, 999).toISOString()
+    )
+  })
+
+  it('stays within the day it was given', () => {
+    const end = new Date(combineDayAndTime(local(2026, 3, 14), DAY_END, true))
+    expect(isSameDay(end, local(2026, 3, 14))).toBe(true)
+    expect(toTimeInput(end)).toBe(DAY_END)
+  })
+
+  it('does not stretch 23:59 when it is a start', () => {
+    expect(combineDayAndTime(local(2026, 3, 14), DAY_END, false)).toBe(
+      local(2026, 3, 14, 23, 59).toISOString()
+    )
+  })
+
+  it('leaves every other end time on the minute', () => {
+    expect(combineDayAndTime(local(2026, 3, 14), '23:58', true)).toBe(
+      local(2026, 3, 14, 23, 58).toISOString()
+    )
+    expect(combineDayAndTime(local(2026, 3, 14), DAY_START, true)).toBe(
+      local(2026, 3, 14).toISOString()
+    )
+  })
+
+  it('falls back to midnight for an unparseable time', () => {
+    expect(combineDayAndTime(local(2026, 3, 14), '', false)).toBe(
+      local(2026, 3, 14).toISOString()
+    )
+  })
+})
+
+describe('toTimeInput', () => {
+  it('pads to the HH:MM an <input type="time"> expects', () => {
+    expect(toTimeInput(local(2026, 3, 14, 9, 5))).toBe('09:05')
+    expect(toTimeInput(local(2026, 3, 14, 0, 0))).toBe('00:00')
+    expect(toTimeInput(local(2026, 3, 14, 23, 59))).toBe('23:59')
+  })
+
+  it('is empty without a date, which blanks the field', () => {
+    expect(toTimeInput(undefined)).toBe('')
+  })
+
+  // The popover reads its fields back off the bounds it emitted, so the pair has to
+  // round-trip or picking a second day would move the times
+  it('round-trips a whole-day selection', () => {
+    const day = local(2026, 3, 14)
+    const start = new Date(combineDayAndTime(day, DAY_START, false))
+    const end = new Date(combineDayAndTime(day, DAY_END, true))
+    expect([toTimeInput(start), toTimeInput(end)]).toEqual([DAY_START, DAY_END])
+  })
+})
+
+describe('startOfDay', () => {
+  it('clears the time without touching the original', () => {
+    const original = local(2026, 3, 14, 17, 45, 30, 123)
+    expect(startOfDay(original)).toEqual(local(2026, 3, 14))
+    expect(original).toEqual(local(2026, 3, 14, 17, 45, 30, 123))
+  })
+})
+
+describe('addDays', () => {
+  it('crosses month and year boundaries', () => {
+    expect(addDays(local(2026, 1, 31), 1)).toEqual(local(2026, 2, 1))
+    expect(addDays(local(2026, 12, 31), 1)).toEqual(local(2027, 1, 1))
+    expect(addDays(local(2026, 3, 1), -1)).toEqual(local(2026, 2, 28))
+  })
+
+  it('lands on Feb 29 in a leap year', () => {
+    expect(addDays(local(2024, 2, 28), 1)).toEqual(local(2024, 2, 29))
+  })
+
+  it('does not mutate its argument', () => {
+    const original = local(2026, 3, 14)
+    addDays(original, 5)
+    expect(original).toEqual(local(2026, 3, 14))
+  })
+
+  // How the day strip is built: today last, the six preceding days before it
+  it('builds a contiguous strip ending today', () => {
+    const today = local(2026, 3, 1)
+    const strip = Array.from({ length: 7 }, (_, i) => addDays(today, i - 6))
+    expect(strip[0]).toEqual(local(2026, 2, 23))
+    expect(strip[6]).toEqual(today)
+  })
+})
+
+describe('isSameDay', () => {
+  it('compares the day, not the distance', () => {
+    expect(isSameDay(local(2026, 3, 14, 0, 0), local(2026, 3, 14, 23, 59, 59, 999))).toBe(
+      true
+    )
+    expect(isSameDay(local(2026, 3, 14, 23, 59), local(2026, 3, 15, 0, 0))).toBe(false)
+  })
+})
+
+describe('resolveTimeFilter', () => {
+  const anchor = new Date('2026-03-14T12:00:00.000Z')
+
+  it('anchors a relative filter and leaves it open-ended', () => {
+    expect(resolveTimeFilter({ kind: 'relative', minutes: 15 }, anchor)).toEqual({
+      start: '2026-03-14T11:45:00.000Z',
+    })
+  })
+
+  it('resolves the widest relative window the charts allow', () => {
+    const { start } = resolveTimeFilter(
+      { kind: 'relative', minutes: MAX_RELATIVE_MINUTES },
+      anchor
+    )
+    expect(start).toBe('2026-03-07T12:00:00.000Z')
+  })
+
+  it('slides with the anchor, which is what keeps paging stable between refreshes', () => {
+    const later = new Date(anchor.getTime() + 60_000)
+    expect(resolveTimeFilter({ kind: 'relative', minutes: 15 }, later)).toEqual({
+      start: '2026-03-14T11:46:00.000Z',
+    })
+  })
+
+  it('passes an absolute filter through, ignoring the anchor', () => {
+    expect(
+      resolveTimeFilter({ kind: 'absolute', start: '2026-03-14T00:00:00.000Z' }, anchor)
+    ).toEqual({ start: '2026-03-14T00:00:00.000Z', end: undefined })
+  })
+})
+
+describe('overlapsRange', () => {
+  // A day cell in the strip, which is what the range is tested against
+  const day: [Date, Date] = [
+    new Date('2026-03-14T00:00:00.000Z'),
+    new Date('2026-03-15T00:00:00.000Z'),
+  ]
+
+  it('treats an unbounded side as reaching forever', () => {
+    expect(overlapsRange({}, ...day)).toBe(true)
+    expect(overlapsRange({ start: '2020-01-01T00:00:00.000Z' }, ...day)).toBe(true)
+    expect(overlapsRange({ end: '2030-01-01T00:00:00.000Z' }, ...day)).toBe(true)
+  })
+
+  // Both sides are half-open: a range ending exactly where the day starts holds no
+  // instant the day holds, so that cell must not light up
+  it('excludes a range that only touches the day at its end', () => {
+    expect(overlapsRange({ end: '2026-03-14T00:00:00.000Z' }, ...day)).toBe(false)
+  })
+
+  it('excludes a range that only touches the day at its start', () => {
+    expect(overlapsRange({ start: '2026-03-15T00:00:00.000Z' }, ...day)).toBe(false)
+  })
+
+  it('includes a range overlapping by a single millisecond', () => {
+    expect(overlapsRange({ end: '2026-03-14T00:00:00.001Z' }, ...day)).toBe(true)
+    expect(overlapsRange({ start: '2026-03-14T23:59:59.999Z' }, ...day)).toBe(true)
+  })
+
+  it('includes a range strictly inside the day', () => {
+    expect(
+      overlapsRange(
+        { start: '2026-03-14T10:00:00.000Z', end: '2026-03-14T11:00:00.000Z' },
+        ...day
+      )
+    ).toBe(true)
+  })
+
+  // The time fields let one be typed, and it matches nothing
+  it('excludes an inverted range', () => {
+    expect(
+      overlapsRange(
+        { start: '2026-03-14T11:00:00.000Z', end: '2026-03-14T10:00:00.000Z' },
+        ...day
+      )
+    ).toBe(false)
+  })
+})
+
+describe('describeTimeFilter', () => {
+  it('reads as unfiltered when there is nothing to describe', () => {
+    expect(describeTimeFilter(null)).toBe('Any time')
+    expect(describeTimeFilter({ kind: 'absolute' })).toBe('Any time')
+  })
+
+  it('names the preset for a relative filter', () => {
+    expect(describeTimeFilter({ kind: 'relative', minutes: 15 })).toBe('Last 15 min')
+  })
+
+  it('drops the repeated date when both bounds fall on one day', () => {
+    expect(
+      describeTimeFilter({
+        kind: 'absolute',
+        start: local(2026, 3, 14, 9, 0).toISOString(),
+        end: local(2026, 3, 14, 17, 30).toISOString(),
+      })
+    ).toBe('Mar 14, 09:00 – 17:30')
+  })
+
+  it('spells out both dates when the range spans days', () => {
+    expect(
+      describeTimeFilter({
+        kind: 'absolute',
+        start: local(2026, 3, 14, 9, 0).toISOString(),
+        end: local(2026, 3, 15, 17, 30).toISOString(),
+      })
+    ).toBe('Mar 14, 09:00 – Mar 15, 17:30')
+  })
+
+  it('describes a whole day by its own date, not the next one', () => {
+    const day = local(2026, 3, 14)
+    expect(
+      describeTimeFilter({
+        kind: 'absolute',
+        start: combineDayAndTime(day, DAY_START, false),
+        end: combineDayAndTime(day, DAY_END, true),
+      })
+    ).toBe('Mar 14, 00:00 – 23:59')
+  })
+
+  it('describes a one-sided range by the bound it has', () => {
+    const bound = local(2026, 3, 14, 9, 0).toISOString()
+    expect(describeTimeFilter({ kind: 'absolute', start: bound })).toBe(
+      'After Mar 14, 09:00'
+    )
+    expect(describeTimeFilter({ kind: 'absolute', end: bound })).toBe(
+      'Before Mar 14, 09:00'
+    )
+  })
+})

--- a/ui/src/utils/time-filter.test.ts
+++ b/ui/src/utils/time-filter.test.ts
@@ -6,6 +6,7 @@ import {
   addDays,
   combineDayAndTime,
   describeTimeFilter,
+  formatMinute,
   isSameDay,
   overlapsRange,
   resolveTimeFilter,
@@ -216,6 +217,23 @@ describe('overlapsRange', () => {
         ...day
       )
     ).toBe(false)
+  })
+})
+
+describe('formatMinute', () => {
+  it('uses a 24-hour clock', () => {
+    expect(formatMinute(local(2026, 3, 14, 13, 5))).toBe('13:05')
+  })
+
+  // `hour12: false` resolves to h24 on some ICU builds, which writes midnight as 24:00
+  // without rolling the date back, so the same label means two different days
+  it('writes midnight as 00:00, not 24:00', () => {
+    expect(formatMinute(local(2026, 3, 14, 0, 0))).toBe('00:00')
+    expect(formatMinute(local(2026, 3, 14, 0, 30))).toBe('00:30')
+  })
+
+  it('writes the last minute of the day as 23:59', () => {
+    expect(formatMinute(local(2026, 3, 14, 23, 59))).toBe('23:59')
   })
 })
 

--- a/ui/src/utils/time-filter.ts
+++ b/ui/src/utils/time-filter.ts
@@ -1,19 +1,13 @@
 import type { TimeRange } from '@/services/api'
 
-// A relative filter re-anchors to the latest refresh, so "last 15 min" keeps sliding;
-// an absolute one is a fixed range (a clicked chart bucket or hand-picked days).
 export type TimeFilter =
   | { kind: 'absolute'; start?: string; end?: string }
   | { kind: 'relative'; minutes: number }
 
-// Capped by the minutes chart, which shows 30 one-minute buckets
 export const TIME_PRESETS = [5, 15, 30]
 
-// The days chart spans a week (28 six-hour buckets, see generateCombinedTimeline),
-// so the day strip offers the same window
 export const STRIP_DAYS = 7
 
-// Bounded by what the charts and the day strip can show
 export const MAX_RELATIVE_MINUTES = STRIP_DAYS * 24 * 60
 
 export const isSameDay = (a: Date, b: Date) => a.toDateString() === b.toDateString()
@@ -30,8 +24,6 @@ export function resolveTimeFilter(filter: TimeFilter, anchor: Date): TimeRange {
 export function overlapsRange(range: TimeRange, spanStart: Date, spanEnd: Date): boolean {
   const start = range.start ? new Date(range.start).getTime() : -Infinity
   const end = range.end ? new Date(range.end).getTime() : Infinity
-  // The time fields allow an inverted range. It holds no instant at all, so nothing
-  // overlaps it — without this the day strip would light up for a filter matching nothing
   if (start >= end) return false
   return spanEnd.getTime() > start && spanStart.getTime() < end
 }
@@ -40,7 +32,6 @@ export function presetLabel(minutes: number): string {
   return `Last ${minutes} min`
 }
 
-// The time fields are `<input type="time">`, so bounds are picked as local wall clock
 export const DAY_START = '00:00'
 export const DAY_END = '23:59'
 
@@ -62,27 +53,20 @@ export function addDays(date: Date, count: number): Date {
   return shifted
 }
 
-// The day strip picks the day, the time fields pick the time within it. The end bound is
-// exclusive, so as an end 23:59 has to stretch to the end of that minute or a whole-day
-// selection would drop its final minute. It stops a millisecond short of the next day so
-// that reading the bound back still lands on the day the user picked.
 export function combineDayAndTime(day: Date, time: string, isEnd: boolean): string {
   const [hours, minutes] = time.split(':').map(Number)
   const endOfDay = isEnd && time === DAY_END
   const combined = new Date(day)
+  // extend to :59:999 at end of day to include as much as possible (save for the last millisecond)
   combined.setHours(hours || 0, minutes || 0, endOfDay ? 59 : 0, endOfDay ? 999 : 0)
   return combined.toISOString()
 }
 
-// Every time label in the UI reads the same way, charts included
 export const LOCALE = 'en-US'
 const DATE_OPTS: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' }
 const TIME_OPTS: Intl.DateTimeFormatOptions = {
   hour: '2-digit',
   minute: '2-digit',
-  // Not `hour12: false`: that resolves to h24 on some ICU builds, which renders
-  // midnight as 24:00. Asking for h23 pins it to 00:00 everywhere. The two cannot be
-  // combined — `hour12` takes precedence over `hourCycle` when both are given.
   hourCycle: 'h23',
 }
 
@@ -90,7 +74,6 @@ export function formatDay(date: Date): string {
   return date.toLocaleDateString(LOCALE, DATE_OPTS)
 }
 
-// Chart axis labels: the days chart is bucketed by hour, the minutes chart by minute
 export function formatDayHour(date: Date): string {
   return date.toLocaleDateString(LOCALE, { ...DATE_OPTS, hour: '2-digit' })
 }

--- a/ui/src/utils/time-filter.ts
+++ b/ui/src/utils/time-filter.ts
@@ -30,11 +30,48 @@ export function resolveTimeFilter(filter: TimeFilter, anchor: Date): TimeRange {
 export function overlapsRange(range: TimeRange, spanStart: Date, spanEnd: Date): boolean {
   const start = range.start ? new Date(range.start).getTime() : -Infinity
   const end = range.end ? new Date(range.end).getTime() : Infinity
+  // The time fields allow an inverted range. It holds no instant at all, so nothing
+  // overlaps it — without this the day strip would light up for a filter matching nothing
+  if (start >= end) return false
   return spanEnd.getTime() > start && spanStart.getTime() < end
 }
 
 export function presetLabel(minutes: number): string {
   return `Last ${minutes} min`
+}
+
+// The time fields are `<input type="time">`, so bounds are picked as local wall clock
+export const DAY_START = '00:00'
+export const DAY_END = '23:59'
+
+const pad = (n: number) => String(n).padStart(2, '0')
+
+export function toTimeInput(date?: Date): string {
+  return date ? `${pad(date.getHours())}:${pad(date.getMinutes())}` : ''
+}
+
+export function startOfDay(date: Date): Date {
+  const day = new Date(date)
+  day.setHours(0, 0, 0, 0)
+  return day
+}
+
+export function addDays(date: Date, count: number): Date {
+  const shifted = new Date(date)
+  shifted.setDate(date.getDate() + count)
+  return shifted
+}
+
+// The day strip picks the day, the time fields pick the time within it. The end bound is
+// exclusive, so as an end 23:59 has to stretch to the end of that minute or a whole-day
+// selection would drop its final minute. It stops a millisecond short of the next day so
+// that reading the bound back still lands on the day the user picked.
+export function combineDayAndTime(day: Date, time: string, isEnd: boolean): string {
+  const [hours, minutes] = time.split(':').map(Number)
+  const endOfDay = isEnd && time === DAY_END
+  const combined = new Date(day)
+  combined.setHours(hours || 0, minutes || 0, endOfDay ? 59 : 0, endOfDay ? 999 : 0)
+  return combined.toISOString()
 }
 
 // Every time label in the UI reads the same way, charts included

--- a/ui/src/utils/time-filter.ts
+++ b/ui/src/utils/time-filter.ts
@@ -1,0 +1,81 @@
+import type { TimeRange } from '@/services/api'
+
+// A relative filter re-anchors to the latest refresh, so "last 15 min" keeps sliding;
+// an absolute one is a fixed range (a clicked chart bucket or hand-picked days).
+export type TimeFilter =
+  | { kind: 'absolute'; start?: string; end?: string }
+  | { kind: 'relative'; minutes: number }
+
+// Capped by the minutes chart, which shows 30 one-minute buckets
+export const TIME_PRESETS = [5, 15, 30]
+
+// The days chart spans a week (28 six-hour buckets, see generateCombinedTimeline),
+// so the day strip offers the same window
+export const STRIP_DAYS = 7
+
+// Bounded by what the charts and the day strip can show
+export const MAX_RELATIVE_MINUTES = STRIP_DAYS * 24 * 60
+
+export const isSameDay = (a: Date, b: Date) => a.toDateString() === b.toDateString()
+
+export function resolveTimeFilter(filter: TimeFilter, anchor: Date): TimeRange {
+  if (filter.kind === 'relative') {
+    return { start: new Date(anchor.getTime() - filter.minutes * 60_000).toISOString() }
+  }
+  return { start: filter.start, end: filter.end }
+}
+
+// Both the range and the span are half-open, matching the backend's
+// `timestamp >= start AND timestamp < end`
+export function overlapsRange(range: TimeRange, spanStart: Date, spanEnd: Date): boolean {
+  const start = range.start ? new Date(range.start).getTime() : -Infinity
+  const end = range.end ? new Date(range.end).getTime() : Infinity
+  return spanEnd.getTime() > start && spanStart.getTime() < end
+}
+
+export function presetLabel(minutes: number): string {
+  return `Last ${minutes} min`
+}
+
+// Every time label in the UI reads the same way, charts included
+export const LOCALE = 'en-US'
+const DATE_OPTS: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' }
+const TIME_OPTS: Intl.DateTimeFormatOptions = {
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+}
+
+export function formatDay(date: Date): string {
+  return date.toLocaleDateString(LOCALE, DATE_OPTS)
+}
+
+// Chart axis labels: the days chart is bucketed by hour, the minutes chart by minute
+export function formatDayHour(date: Date): string {
+  return date.toLocaleDateString(LOCALE, { ...DATE_OPTS, hour: '2-digit' })
+}
+
+export function formatMinute(date: Date): string {
+  return date.toLocaleTimeString(LOCALE, TIME_OPTS)
+}
+
+function formatStamp(date: Date): string {
+  return `${formatDay(date)}, ${formatMinute(date)}`
+}
+
+export function describeTimeFilter(filter: TimeFilter | null): string {
+  if (!filter) return 'Any time'
+  if (filter.kind === 'relative') return presetLabel(filter.minutes)
+
+  const start = filter.start ? new Date(filter.start) : null
+  const end = filter.end ? new Date(filter.end) : null
+
+  if (start && end) {
+    return isSameDay(start, end)
+      ? `${formatStamp(start)} – ${end.toLocaleTimeString(LOCALE, TIME_OPTS)}`
+      : `${formatStamp(start)} – ${formatStamp(end)}`
+  }
+  if (start) return `After ${formatStamp(start)}`
+  if (end) return `Before ${formatStamp(end)}`
+  return 'Any time'
+}

--- a/ui/src/utils/time-filter.ts
+++ b/ui/src/utils/time-filter.ts
@@ -80,7 +80,10 @@ const DATE_OPTS: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' }
 const TIME_OPTS: Intl.DateTimeFormatOptions = {
   hour: '2-digit',
   minute: '2-digit',
-  hour12: false,
+  // Not `hour12: false`: that resolves to h24 on some ICU builds, which renders
+  // midnight as 24:00. Asking for h23 pins it to 00:00 everywhere. The two cannot be
+  // combined — `hour12` takes precedence over `hourCycle` when both are given.
+  hourCycle: 'h23',
 }
 
 export function formatDay(date: Date): string {

--- a/ui/src/utils/view-url.test.ts
+++ b/ui/src/utils/view-url.test.ts
@@ -5,7 +5,6 @@ import { FAILURE_COLUMN, TIMESTAMP_COLUMN } from './fixed-columns'
 import { MAX_RELATIVE_MINUTES, type TimeFilter } from './time-filter'
 import { parseViewUrl, serializeViewUrl } from './view-url'
 
-// Both functions read the current location, so each case installs its own
 const at = (url: string) => {
   const { search, origin, pathname } = new URL(url)
   vi.stubGlobal('window', { location: { search, origin, pathname } })
@@ -71,13 +70,11 @@ describe('parseViewUrl', () => {
     expect(parse('?status=')).toBeNull()
   })
 
-  // Columns can all be deselected, so filters alone are a legitimate view
-  it('restores a filter-only view', () => {
+  it('restores a filter-only view with no selected columns', () => {
     expect(parse('?status=bad')).not.toBeNull()
     expect(parse('?time=last15m')).not.toBeNull()
   })
 
-  // URLs shared before these became fixed columns may still list them
   it('drops references to fixed columns and their nested fields', () => {
     expect(parse(`?${TIMESTAMP_COLUMN}=&app_id=`)?.columns).toEqual(['app_id'])
     expect(parse(`?${FAILURE_COLUMN}.errors=&app_id=`)?.columns).toEqual(['app_id'])
@@ -110,7 +107,6 @@ describe('parseViewUrl', () => {
       })
     })
 
-    // A hand-edited window outside what the charts and the day strip cover
     it('rejects a window of zero or beyond the maximum', () => {
       expect(parse('?time=last0m')).toBeNull()
       expect(parse(`?time=last${MAX_RELATIVE_MINUTES + 1}m`)).toBeNull()
@@ -146,7 +142,6 @@ describe('parseViewUrl', () => {
       })
     })
 
-    // A hand-edited bound that is not a date would otherwise reach Date arithmetic
     it('drops a bound that is not a date, keeping the one that is', () => {
       expect(parse('?time=nonsense~2026-03-15T00%3A00%3A00.000Z')?.timeFilter).toEqual({
         kind: 'absolute',

--- a/ui/src/utils/view-url.test.ts
+++ b/ui/src/utils/view-url.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ColumnFiltersState } from '@tanstack/react-table'
+import { createColumnMetadata } from './column-metadata'
+import { FAILURE_COLUMN, TIMESTAMP_COLUMN } from './fixed-columns'
+import { MAX_RELATIVE_MINUTES, type TimeFilter } from './time-filter'
+import { parseViewUrl, serializeViewUrl } from './view-url'
+
+// Both functions read the current location, so each case installs its own
+const at = (url: string) => {
+  const { search, origin, pathname } = new URL(url)
+  vi.stubGlobal('window', { location: { search, origin, pathname } })
+}
+
+const BASE = 'https://micro.example/micro/ui'
+
+const parse = (query: string) => {
+  at(`${BASE}${query}`)
+  return parseViewUrl()
+}
+
+const serialize = (
+  columns: string[],
+  filters: ColumnFiltersState = [],
+  timeFilter: TimeFilter | null = null
+) => {
+  at(BASE)
+  return serializeViewUrl(columns.map(createColumnMetadata), filters, timeFilter)
+}
+
+const query = (url: string) => url.slice(`${BASE}?`.length)
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('parseViewUrl', () => {
+  it('is null when there is nothing to restore', () => {
+    expect(parse('')).toBeNull()
+    expect(parse('?')).toBeNull()
+  })
+
+  it('reads a column with no filter as selected but unfiltered', () => {
+    expect(parse('?app_id=')).toEqual({
+      columns: ['app_id'],
+      filters: [],
+      timeFilter: null,
+    })
+  })
+
+  it('splits a multi-value column filter on ~', () => {
+    expect(parse('?app_id=web~mobile')).toEqual({
+      columns: ['app_id'],
+      filters: [{ id: 'app_id', value: ['web', 'mobile'] }],
+      timeFilter: null,
+    })
+  })
+
+  it('keeps column order, which is the order they are shown in', () => {
+    expect(parse('?b=&a=&c=')?.columns).toEqual(['b', 'a', 'c'])
+  })
+
+  it('carries the status filter as a scalar, not a column', () => {
+    expect(parse('?status=good')).toEqual({
+      columns: [],
+      filters: [{ id: 'status', value: 'good' }],
+      timeFilter: null,
+    })
+  })
+
+  it('ignores an empty status', () => {
+    expect(parse('?status=')).toBeNull()
+  })
+
+  // Columns can all be deselected, so filters alone are a legitimate view
+  it('restores a filter-only view', () => {
+    expect(parse('?status=bad')).not.toBeNull()
+    expect(parse('?time=last15m')).not.toBeNull()
+  })
+
+  // URLs shared before these became fixed columns may still list them
+  it('drops references to fixed columns and their nested fields', () => {
+    expect(parse(`?${TIMESTAMP_COLUMN}=&app_id=`)?.columns).toEqual(['app_id'])
+    expect(parse(`?${FAILURE_COLUMN}.errors=&app_id=`)?.columns).toEqual(['app_id'])
+  })
+
+  it('drops a fixed column even when it carries a filter', () => {
+    expect(parse(`?${FAILURE_COLUMN}=oops`)).toBeNull()
+  })
+
+  it('decodes percent-encoded column names and values', () => {
+    expect(parse('?unstruct_event_x.a%20b=one%20two')).toEqual({
+      columns: ['unstruct_event_x.a b'],
+      filters: [{ id: 'unstruct_event_x.a b', value: ['one two'] }],
+      timeFilter: null,
+    })
+  })
+
+  describe('the time parameter', () => {
+    it('reads a relative window', () => {
+      expect(parse('?time=last15m')?.timeFilter).toEqual({
+        kind: 'relative',
+        minutes: 15,
+      })
+    })
+
+    it('accepts the widest window the charts can show', () => {
+      expect(parse(`?time=last${MAX_RELATIVE_MINUTES}m`)?.timeFilter).toEqual({
+        kind: 'relative',
+        minutes: MAX_RELATIVE_MINUTES,
+      })
+    })
+
+    // A hand-edited window outside what the charts and the day strip cover
+    it('rejects a window of zero or beyond the maximum', () => {
+      expect(parse('?time=last0m')).toBeNull()
+      expect(parse(`?time=last${MAX_RELATIVE_MINUTES + 1}m`)).toBeNull()
+    })
+
+    it('does not mistake a near-miss of the relative form for a range', () => {
+      expect(parse('?time=last15')).toBeNull()
+      expect(parse('?time=last-5m')).toBeNull()
+      expect(parse('?time=lastm')).toBeNull()
+    })
+
+    it('reads an absolute range', () => {
+      expect(
+        parse('?time=2026-03-14T00%3A00%3A00.000Z~2026-03-15T00%3A00%3A00.000Z')
+          ?.timeFilter
+      ).toEqual({
+        kind: 'absolute',
+        start: '2026-03-14T00:00:00.000Z',
+        end: '2026-03-15T00:00:00.000Z',
+      })
+    })
+
+    it('reads a one-sided range from either side', () => {
+      expect(parse('?time=2026-03-14T00%3A00%3A00.000Z~')?.timeFilter).toEqual({
+        kind: 'absolute',
+        start: '2026-03-14T00:00:00.000Z',
+        end: undefined,
+      })
+      expect(parse('?time=~2026-03-15T00%3A00%3A00.000Z')?.timeFilter).toEqual({
+        kind: 'absolute',
+        start: undefined,
+        end: '2026-03-15T00:00:00.000Z',
+      })
+    })
+
+    // A hand-edited bound that is not a date would otherwise reach Date arithmetic
+    it('drops a bound that is not a date, keeping the one that is', () => {
+      expect(parse('?time=nonsense~2026-03-15T00%3A00%3A00.000Z')?.timeFilter).toEqual({
+        kind: 'absolute',
+        start: undefined,
+        end: '2026-03-15T00:00:00.000Z',
+      })
+    })
+
+    it('ignores the filter when neither bound is a date', () => {
+      expect(parse('?time=nonsense~rubbish')).toBeNull()
+      expect(parse('?time=')).toBeNull()
+      expect(parse('?time=~')).toBeNull()
+    })
+  })
+})
+
+describe('serializeViewUrl', () => {
+  it('keeps the current page as the base', () => {
+    expect(serialize(['app_id'])).toBe(`${BASE}?app_id=`)
+  })
+
+  it('writes a selected column with no filter as a bare name', () => {
+    expect(query(serialize(['app_id', 'platform']))).toBe('app_id=&platform=')
+  })
+
+  it('joins multi-value filters with ~', () => {
+    expect(
+      query(serialize(['app_id'], [{ id: 'app_id', value: ['web', 'mobile'] }]))
+    ).toBe('app_id=web~mobile')
+  })
+
+  it('ignores filters on columns that are not selected', () => {
+    expect(query(serialize(['app_id'], [{ id: 'platform', value: ['web'] }]))).toBe(
+      'app_id='
+    )
+  })
+
+  it('puts status after the columns, whether or not any are selected', () => {
+    expect(query(serialize(['app_id'], [{ id: 'status', value: 'bad' }]))).toBe(
+      'app_id=&status=bad'
+    )
+    expect(query(serialize([], [{ id: 'status', value: 'bad' }]))).toBe('status=bad')
+  })
+
+  it('writes a relative filter as the sliding form, not as resolved bounds', () => {
+    expect(query(serialize([], [], { kind: 'relative', minutes: 15 }))).toBe(
+      'time=last15m'
+    )
+  })
+
+  it('writes both bounds of an absolute filter, keeping the separator when one is missing', () => {
+    expect(
+      query(
+        serialize([], [], {
+          kind: 'absolute',
+          start: '2026-03-14T00:00:00.000Z',
+          end: '2026-03-15T00:00:00.000Z',
+        })
+      )
+    ).toBe('time=2026-03-14T00%3A00%3A00.000Z~2026-03-15T00%3A00%3A00.000Z')
+
+    expect(
+      query(serialize([], [], { kind: 'absolute', start: '2026-03-14T00:00:00.000Z' }))
+    ).toBe('time=2026-03-14T00%3A00%3A00.000Z~')
+  })
+
+  it('leaves the time parameter out when nothing is filtered', () => {
+    expect(query(serialize(['app_id'], [], null))).toBe('app_id=')
+  })
+
+  it('escapes the separator characters in names and values', () => {
+    const url = query(serialize(['a&b=c'], [{ id: 'a&b=c', value: ['x y'] }]))
+    expect(url).toBe('a%26b%3Dc=x%20y')
+  })
+})
+
+describe('a view round-trips through the URL', () => {
+  const roundTrip = (
+    columns: string[],
+    filters: ColumnFiltersState,
+    timeFilter: TimeFilter | null
+  ) => {
+    const url = serializeViewUrl(columns.map(createColumnMetadata), filters, timeFilter)
+    return parse(`?${query(url)}`)
+  }
+
+  it('preserves columns, filters and a relative time filter', () => {
+    at(BASE)
+    expect(
+      roundTrip(
+        ['app_id', 'platform'],
+        [
+          { id: 'app_id', value: ['web', 'mobile'] },
+          { id: 'status', value: 'bad' },
+        ],
+        { kind: 'relative', minutes: 30 }
+      )
+    ).toEqual({
+      columns: ['app_id', 'platform'],
+      filters: [
+        { id: 'app_id', value: ['web', 'mobile'] },
+        { id: 'status', value: 'bad' },
+      ],
+      timeFilter: { kind: 'relative', minutes: 30 },
+    })
+  })
+
+  it('preserves an absolute time filter and awkward names', () => {
+    at(BASE)
+    expect(
+      roundTrip(
+        ['unstruct_event_my_schema_1.a b'],
+        [{ id: 'unstruct_event_my_schema_1.a b', value: ['one two', 'three&four'] }],
+        { kind: 'absolute', start: '2026-03-14T00:00:00.000Z' }
+      )
+    ).toEqual({
+      columns: ['unstruct_event_my_schema_1.a b'],
+      filters: [
+        { id: 'unstruct_event_my_schema_1.a b', value: ['one two', 'three&four'] },
+      ],
+      timeFilter: { kind: 'absolute', start: '2026-03-14T00:00:00.000Z', end: undefined },
+    })
+  })
+})

--- a/ui/src/utils/view-url.ts
+++ b/ui/src/utils/view-url.ts
@@ -9,10 +9,8 @@ export type UrlViewState = {
   timeFilter: TimeFilter | null
 }
 
-// Relative filters serialize as `last<minutes>m` so a shared URL keeps sliding with time
 const RELATIVE_TIME = /^last(\d+)m$/
 
-// A hand-edited bound that is not a date would otherwise reach Date arithmetic and throw
 const timestamp = (value: string): string | undefined =>
   value && !Number.isNaN(new Date(value).getTime()) ? value : undefined
 
@@ -31,7 +29,6 @@ export function parseViewUrl(): UrlViewState | null {
     } else if (key === 'time') {
       const relative = RELATIVE_TIME.exec(value)
       if (relative) {
-        // Bounded by what the charts and the day strip can show
         const minutes = Number(relative[1])
         if (minutes > 0 && minutes <= MAX_RELATIVE_MINUTES) {
           timeFilter = { kind: 'relative', minutes }
@@ -45,7 +42,6 @@ export function parseViewUrl(): UrlViewState | null {
         }
       }
     } else if (!isFixedColumn(key)) {
-      // URLs shared before these columns became fixed may still list them
       columns.push(key)
       if (value) {
         filters.push({ id: key, value: value.split('~') })
@@ -53,7 +49,6 @@ export function parseViewUrl(): UrlViewState | null {
     }
   }
 
-  // Columns can all be deselected, so a URL may legitimately carry only filters
   if (columns.length === 0 && filters.length === 0 && !timeFilter) return null
   return { columns, filters, timeFilter }
 }

--- a/ui/src/utils/view-url.ts
+++ b/ui/src/utils/view-url.ts
@@ -1,18 +1,27 @@
 import type { ColumnFiltersState } from '@tanstack/react-table'
 import type { ColumnMetadata } from '@/utils/column-metadata'
+import { isFixedColumn } from '@/utils/fixed-columns'
+import { MAX_RELATIVE_MINUTES, type TimeFilter } from '@/utils/time-filter'
 
 export type UrlViewState = {
   columns: string[]
   filters: ColumnFiltersState
-  timeBucket: string | null
+  timeFilter: TimeFilter | null
 }
+
+// Relative filters serialize as `last<minutes>m` so a shared URL keeps sliding with time
+const RELATIVE_TIME = /^last(\d+)m$/
+
+// A hand-edited bound that is not a date would otherwise reach Date arithmetic and throw
+const timestamp = (value: string): string | undefined =>
+  value && !Number.isNaN(new Date(value).getTime()) ? value : undefined
 
 export function parseViewUrl(): UrlViewState | null {
   const params = new URLSearchParams(window.location.search)
 
   const columns: string[] = []
   const filters: ColumnFiltersState = []
-  let timeBucket: string | null = null
+  let timeFilter: TimeFilter | null = null
 
   for (const [key, value] of params) {
     if (key === 'status') {
@@ -20,11 +29,23 @@ export function parseViewUrl(): UrlViewState | null {
         filters.push({ id: 'status', value })
       }
     } else if (key === 'time') {
-      const parts = value.split('~')
-      if (parts.length === 2) {
-        timeBucket = `${parts[0]}|${parts[1]}`
+      const relative = RELATIVE_TIME.exec(value)
+      if (relative) {
+        // Bounded by what the charts and the day strip can show
+        const minutes = Number(relative[1])
+        if (minutes > 0 && minutes <= MAX_RELATIVE_MINUTES) {
+          timeFilter = { kind: 'relative', minutes }
+        }
+      } else {
+        const parts = value.split('~')
+        const start = timestamp(parts[0] ?? '')
+        const end = timestamp(parts[1] ?? '')
+        if (start || end) {
+          timeFilter = { kind: 'absolute', start, end }
+        }
       }
-    } else {
+    } else if (!isFixedColumn(key)) {
+      // URLs shared before these columns became fixed may still list them
       columns.push(key)
       if (value) {
         filters.push({ id: key, value: value.split('~') })
@@ -32,14 +53,15 @@ export function parseViewUrl(): UrlViewState | null {
     }
   }
 
-  if (columns.length === 0) return null
-  return { columns, filters, timeBucket }
+  // Columns can all be deselected, so a URL may legitimately carry only filters
+  if (columns.length === 0 && filters.length === 0 && !timeFilter) return null
+  return { columns, filters, timeFilter }
 }
 
 export function serializeViewUrl(
   selectedColumns: ColumnMetadata[],
   columnFilters: ColumnFiltersState,
-  selectedTimeBucket: string | null,
+  timeFilter: TimeFilter | null,
 ): string {
   const parts: string[] = []
 
@@ -65,9 +87,12 @@ export function serializeViewUrl(
     parts.push(`status=${encodeURIComponent(String(statusFilter.value))}`)
   }
 
-  if (selectedTimeBucket) {
-    const [start, end] = selectedTimeBucket.split('|')
-    parts.push(`time=${encodeURIComponent(start)}~${encodeURIComponent(end)}`)
+  if (timeFilter?.kind === 'relative') {
+    parts.push(`time=last${timeFilter.minutes}m`)
+  } else if (timeFilter) {
+    parts.push(
+      `time=${encodeURIComponent(timeFilter.start ?? '')}~${encodeURIComponent(timeFilter.end ?? '')}`
+    )
   }
 
   return `${window.location.origin}${window.location.pathname}?${parts.join('&')}`


### PR DESCRIPTION
Add a time range filter to the collector_tstamp column

Filter events by collector_tstamp from the column's filter row. The filter is either an absolute range or a relative window ("last 15 min") that re-anchors on every refresh, so paging stays stable between refreshes. It is the same state the charts write when a bar is clicked, so the column and the charts always agree, and it round-trips through the shareable view URL.

Make collector_tstamp a fixed column alongside Status: it now carries the filter, and both are backed by a field that is never part of the user's column selection. Selections persisted in localStorage or shared in a URL may still mention either field, and those references are ignored.

The backend already accepted EventsRequest.timeRange, so this is a UI change only.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Also adding an index on `network_userid`.