### PR TITLE
Fix application-dependency CVEs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,9 @@ lazy val buildSettings = Seq(
 lazy val dependencies = Seq(
   libraryDependencies ++= Seq(
     Dependencies.snowplowStreamCollector,
+    Dependencies.http4sBlazeServer,
+    Dependencies.http4sBlazeClient,
+    Dependencies.httpClient5,
     Dependencies.snowplowCommonEnrich,
     Dependencies.snowplowAnalyticsSdk,
     Dependencies.decline,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,9 @@ object Dependencies {
     val snowplowCommonEnrich    = "6.13.1"
     val snowplowAnalyticsSdk    = "3.2.0"
 
-    val http4s = "0.23.33"
+    val http4s      = "0.23.33"
+    val http4sBlaze = "0.23.18" // Fix CVE for HTTP request smuggling / DoS in blaze
+    val httpClient5 = "5.6.3"   // Fix CVE-2026-64607 in the version pulled in by libthrift
     val decline     = "2.4.1"
     val catsRetry   = "3.1.3"
     val slf4j       = "2.0.17"
@@ -67,5 +69,11 @@ object Dependencies {
   val googleCloudStorage = "com.google.cloud"       % "google-cloud-storage" % V.gcpSdk
   val azureStorageBlob   = "com.azure"              % "azure-storage-blob"   % V.azureStorageBlob
   val azureIdentity      = "com.azure"              %  "azure-identity"      % V.azureIdentity
+
+  // Declared directly to evict the vulnerable blaze 0.23.15
+  val http4sBlazeServer = "org.http4s" %% "http4s-blaze-server" % V.http4sBlaze
+  val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % V.http4sBlaze
+  // Declared directly to evict the vulnerable httpclient5 5.2.1 pulled in by libthrift
+  val httpClient5       = "org.apache.httpcomponents.client5" % "httpclient5" % V.httpClient5
 
 }


### PR DESCRIPTION
Evicts vulnerable transitive dependencies by declaring them directly at fixed versions.

## CVEs fixed (app-dependency scan, both images)

| | Critical | High | Medium | Total |
|---|---|---|---|---|
| Before | 3 | 2 | 1 | 6 |
| After | 0 | 0 | 0 | **0** |

- **http4s blaze `0.23.15 → 0.23.18`** — pulled in transitively via `snowplow-stream-collector-http4s-core`. Fixes CVE-2026-73495 + 2 unassigned HTTP request smuggling (critical) and CVE-2026-73493 resource-allocation/DoS (high). Added `http4s-blaze-server` + `http4s-blaze-client` directly (lifts shared `http4s-blaze-core`/`blaze-http`).
- **httpclient5 `5.2.1 → 5.6.3`** — pulled in via `libthrift` (runtime scope; only used by thrift's unused `THttpClient` transport). Fixes CVE-2026-64607 (medium). `httpcore5` rides along `5.2 → 5.4.3`.

## Verification
- `sbt micro/evicted` confirms each fixed version is *selected over* the vulnerable one.
- `sbt micro/test` → 131/131 pass.
- Snyk scan of the rebuilt image reports **0 application CVEs** (down from 6).

## Out of scope
Base-image OS CVEs (eclipse-temurin 129 / distroless 17) are not addressed here — base images are hardcoded in `build.sbt` and refreshed by CI's fresh pulls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

ref: https://snplow.atlassian.net/browse/PDP-2817