### PR TITLE
Bump netty to 4.2.17.Final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,8 @@ lazy val dependencies = Seq(
     Dependencies.awsSts,
     Dependencies.googleCloudStorage,
     Dependencies.azureStorageBlob,
-    Dependencies.azureIdentity
+    Dependencies.azureIdentity,
+    Dependencies.nettyAll
   )
 )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,6 +23,7 @@ object Dependencies {
     val http4s      = "0.23.33"
     val http4sBlaze = "0.23.18" // Fix CVE for HTTP request smuggling / DoS in blaze
     val httpClient5 = "5.6.3"   // Fix CVE-2026-64607 in the version pulled in by libthrift
+    val netty       = "4.2.17.Final" // Fix CVE-2026-59902 (SCTP OOM) & CVE-2026-59903 (CORS Vary cache poisoning) in netty 4.2.16 pulled in by snowplow-common-enrich
     val decline     = "2.4.1"
     val catsRetry   = "3.1.3"
     val slf4j       = "2.0.17"
@@ -75,5 +76,7 @@ object Dependencies {
   val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % V.http4sBlaze
   // Declared directly to evict the vulnerable httpclient5 5.2.1 pulled in by libthrift
   val httpClient5       = "org.apache.httpcomponents.client5" % "httpclient5" % V.httpClient5
+  // Declared directly to evict the vulnerable netty 4.2.16 pulled in by snowplow-common-enrich (via netty-all)
+  val nettyAll          = "io.netty" % "netty-all" % V.netty
 
 }


### PR DESCRIPTION
## What

Declares `io.netty:netty-all` directly at `4.2.17.Final` to evict the vulnerable `4.2.16.Final` pulled in transitively by `snowplow-common-enrich 6.13.1`.

## Why

Docker Scout flagged two netty CVEs in the built image (Snyk missed them — both are 2026-dated and too new for Snyk's DB):

| CVE | Severity | Module | Issue |
|-----|----------|--------|-------|
| CVE-2026-59902 | 7.5 High | `netty-transport-sctp` | Memory exhaustion in `SctpMessageCompletionHandler` (unbounded buffered fragments → OOM) |
| CVE-2026-59903 | 6.5 Medium | `netty-codec-http` | `CorsHandler` overwrites existing `Vary` headers → cache poisoning / info disclosure |

Both are fixed in netty `4.2.17.Final`. The override matches the existing "declared directly to evict vulnerable X" pattern used for blaze and httpclient5.

## Verification

- `sbt evicted`: all netty modules — including `netty-transport-sctp` and `netty-codec-http` — resolve to `4.2.17.Final`, across both the common-enrich (`netty-all`) and azure (`azure-core-http-netty`) paths.
- Physical jar listing in the built **distroless** image confirms every netty module jar is `4.2.17.Final`; no `4.2.16`/`4.1.x` module remains.
- `docker scout` on the distroless image: **0 critical / 0 high / 0 medium** — clean.
- `sbt micro/test`: **131 passed, 0 failed, 0 errors**.

## Notes

- Only the **distroless** image is deployed, so this fully clears its critical/high CVEs. The eclipse-temurin `micro` image separately carries golang/stdlib CVEs from a stray `/usr/bin/pebble` Go binary baked into the `eclipse-temurin:21` base — an upstream Temurin issue, not addressed here since that image isn't shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)