### PR TITLE
Prepare for 4.5.1 release

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 4.5.1 (2026-08-18)
+--------------------------
+Bump netty to 4.2.17.Final (#215)
+
 Version 4.5.0 (2026-08-18)
 --------------------------
 Fix application-dependency CVEs (#214)

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,8 @@ lazy val dependencies = Seq(
     Dependencies.awsSts,
     Dependencies.googleCloudStorage,
     Dependencies.azureStorageBlob,
-    Dependencies.azureIdentity
+    Dependencies.azureIdentity,
+    Dependencies.nettyAll
   )
 )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,6 +23,7 @@ object Dependencies {
     val http4s      = "0.23.33"
     val http4sBlaze = "0.23.18" // Fix CVE for HTTP request smuggling / DoS in blaze
     val httpClient5 = "5.6.3"   // Fix CVE-2026-64607 in the version pulled in by libthrift
+    val netty       = "4.2.17.Final" // Fix CVE-2026-59902 (SCTP OOM) & CVE-2026-59903 (CORS Vary cache poisoning) in netty 4.2.16 pulled in by snowplow-common-enrich
     val decline     = "2.4.1"
     val catsRetry   = "3.1.3"
     val slf4j       = "2.0.17"
@@ -75,5 +76,7 @@ object Dependencies {
   val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % V.http4sBlaze
   // Declared directly to evict the vulnerable httpclient5 5.2.1 pulled in by libthrift
   val httpClient5       = "org.apache.httpcomponents.client5" % "httpclient5" % V.httpClient5
+  // Declared directly to evict the vulnerable netty 4.2.16 pulled in by snowplow-common-enrich (via netty-all)
+  val nettyAll          = "io.netty" % "netty-all" % V.netty
 
 }


### PR DESCRIPTION
## Release 4.5.1

Patch release. Sole change since 4.5.0:

- **Bump netty to 4.2.17.Final (#215)** — fixes CVE-2026-59902 (High, `netty-transport-sctp` memory exhaustion) and CVE-2026-59903 (Medium, `netty-codec-http` CORS `Vary` cache poisoning), pulled in transitively via `snowplow-common-enrich`.

### CHANGELOG
```
Version 4.5.1 (2026-08-18)
--------------------------
Bump netty to 4.2.17.Final (#215)
```

### Verification (from #215)
- `sbt evicted`: all netty modules resolve to 4.2.17.Final across both the common-enrich and azure paths.
- Deployed **distroless** image scanned clean of critical/high CVEs (Docker Scout).
- `sbt micro/test`: 131 passed, 0 failed.

Tagging `micro-4.5.1-rc1` off this branch for a release-candidate build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

ref: https://snplow.atlassian.net/browse/PDP-2838