### PR TITLE
Pin netty-tcnative to 2.0.81.Final to match netty 4.2.17

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,8 @@ lazy val dependencies = Seq(
     Dependencies.googleCloudStorage,
     Dependencies.azureStorageBlob,
     Dependencies.azureIdentity,
-    Dependencies.nettyAll
+    Dependencies.nettyAll,
+    Dependencies.nettyTcnative
   )
 )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,6 +24,7 @@ object Dependencies {
     val http4sBlaze = "0.23.18" // Fix CVE for HTTP request smuggling / DoS in blaze
     val httpClient5 = "5.6.3"   // Fix CVE-2026-64607 in the version pulled in by libthrift
     val netty       = "4.2.17.Final" // Fix CVE-2026-59902 (SCTP OOM) & CVE-2026-59903 (CORS Vary cache poisoning) in netty 4.2.16 pulled in by snowplow-common-enrich
+    val tcnative    = "2.0.81.Final"  // Align with netty 4.2.17: its OpenSSL engine calls SSL.getGroupName(long), absent in the transitively-pulled 2.0.78
     val decline     = "2.4.1"
     val catsRetry   = "3.1.3"
     val slf4j       = "2.0.17"
@@ -78,5 +79,7 @@ object Dependencies {
   val httpClient5       = "org.apache.httpcomponents.client5" % "httpclient5" % V.httpClient5
   // Declared directly to evict the vulnerable netty 4.2.16 pulled in by snowplow-common-enrich (via netty-all)
   val nettyAll          = "io.netty" % "netty-all" % V.netty
+  // Declared directly to evict tcnative 2.0.78 (aligned with netty 4.2.16) which lacks SSL.getGroupName(long) that netty 4.2.17 calls
+  val nettyTcnative     = "io.netty" % "netty-tcnative-boringssl-static" % V.tcnative
 
 }


### PR DESCRIPTION
## Problem

The `4.5.1` release fails at TLS handshake time with:

```
java.lang.NoSuchMethodError: 'java.lang.String io.netty.internal.tcnative.SSL.getGroupName(long)'
    at io.netty.handler.ssl.ReferenceCountedOpenSslEngine$DefaultOpenSslSession.handshakeFinished(...)
    ...
```

`4.5.0` is unaffected — the netty bump below landed after the `4.5.0` release commit and before `4.5.1`.

## Root cause

Bumping netty to `4.2.17.Final` (#215) via `netty-all` correctly evicted the CVE-vulnerable `4.2.16` handler/codec modules, but left the **native TLS binding** — `netty-tcnative-boringssl-static` — at `2.0.78.Final`, the version transitively aligned to netty `4.2.16`.

netty `4.2.17`'s OpenSSL engine calls `io.netty.internal.tcnative.SSL.getGroupName(long)`, a method **absent** from tcnative `2.0.78`. It only appears at runtime because it's a native method-resolution failure that fires on an actual TLS handshake, so it wasn't caught at compile time.

netty `4.2.17.Final` aligns to tcnative `2.0.81.Final` (per its parent POM).

## Fix

Declare `netty-tcnative-boringssl-static` directly at `2.0.81.Final` to evict `2.0.78.Final`, matching the existing evict-vulnerable pattern already used for `netty-all`, blaze and httpclient5.

## Verification

- `sbt` resolves both `netty-tcnative-classes` and `netty-tcnative-boringssl-static` to `2.0.81.Final`, with **zero** `2.0.78` references left on the classpath (`2.0.81 is selected over {2.0.78}`).
- Confirmed via decompilation that `2.0.81`'s `SSL` class declares `getGroupName(long)` and `2.0.78`'s does not.
- `sbt compile` succeeds.

> [!NOTE]
> Follow-up: any future netty version change must bump the aligned tcnative in the same PR to avoid this latent gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)